### PR TITLE
Changed APIs

### DIFF
--- a/crates/signature/Cargo.toml
+++ b/crates/signature/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 # Core dependencies, always included
+bincode = "1.3"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -15,10 +16,12 @@ tiny-keccak = { version = "2.0.0", features = ["keccak"] }
 bs58 = "0.5"
 
 # Optional crypto libraries
-ed25519-dalek = { workspace = true, optional = true }
-secp256k1 = { workspace = true, optional = true, features = ["std"] }
+ed25519-dalek = { workspace = true }
+secp256k1 = { workspace = true, features = ["std"] }
 
 [features]
-default = ["ed25519", "secp256k1"]
-ed25519 = ["dep:ed25519-dalek"]
-secp256k1 = ["dep:secp256k1"]
+secp256k1 = []
+# [features]
+# default = ["ed25519"]
+# ed25519 = ["dep:ed25519-dalek"]
+# secp256k1 = ["dep:secp256k1]

--- a/crates/signature/Cargo.toml
+++ b/crates/signature/Cargo.toml
@@ -16,12 +16,10 @@ tiny-keccak = { version = "2.0.0", features = ["keccak"] }
 bs58 = "0.5"
 
 # Optional crypto libraries
-ed25519-dalek = { workspace = true }
-secp256k1 = { workspace = true, features = ["std"] }
+ed25519-dalek = { workspace = true, optional = true }
+secp256k1 = { workspace = true, features = ["std"], optional = true }
 
 [features]
-secp256k1 = []
-# [features]
-# default = ["ed25519"]
-# ed25519 = ["dep:ed25519-dalek"]
-# secp256k1 = ["dep:secp256k1]
+default = ["secp256k1"]
+ed25519 = ["dep:ed25519-dalek"]
+secp256k1 = ["dep:secp256k1"]

--- a/crates/signature/src/ecdsa.rs
+++ b/crates/signature/src/ecdsa.rs
@@ -1,0 +1,135 @@
+use crate::{Signature, SignatureError, SignatureScheme};
+use secp256k1::{
+    ecdsa::Signature as EcdsaSignature, Message, PublicKey, Secp256k1, SecretKey as PrivateKey,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{str::FromStr, sync::LazyLock};
+
+static SECP256K1_SIGNING: LazyLock<Secp256k1<secp256k1::SignOnly>> =
+    LazyLock::new(|| Secp256k1::signing_only());
+static SECP256K1_VERIFY: LazyLock<Secp256k1<secp256k1::VerifyOnly>> =
+    LazyLock::new(|| Secp256k1::verification_only());
+
+#[derive(Clone)]
+pub struct SigningKey(PrivateKey);
+
+impl FromStr for SigningKey {
+    type Err = SignatureError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let private_key =
+            PrivateKey::from_str(s).map_err(|error| Error::CreateSigningKey(error.into()))?;
+        Ok(Self(private_key))
+    }
+}
+
+impl super::Signer for SigningKey {
+    fn from_slice(slice: &[u8]) -> Result<Self, SignatureError> {
+        let private_key =
+            PrivateKey::from_slice(slice).map_err(|error| Error::CreateSigningKey(error.into()))?;
+        Ok(Self(private_key))
+    }
+
+    fn verifying_key(&self) -> impl crate::Verifier {
+        let secp = Secp256k1::new();
+        VerifyingKey(PublicKey::from_secret_key(&secp, &self.0))
+    }
+
+    fn sign<T: Serialize>(&self, message: &T) -> Result<Signature, SignatureError> {
+        let message_bytes =
+            bincode::serialize(message).map_err(|error| Error::Sign(error.into()))?;
+        let msg_hash = Sha256::digest(message_bytes);
+        let message = Message::from_digest_slice(msg_hash.as_slice())
+            .map_err(|error| Error::Sign(error.into()))?;
+        let secp256k1 = &SECP256K1_SIGNING;
+        let signature = secp256k1.sign_ecdsa(&message, &self.0).serialize_compact();
+        Ok(Signature {
+            bytes: signature.to_vec(),
+            scheme: SignatureScheme::Secp256k1,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "String")]
+#[serde(into = "String")]
+pub struct VerifyingKey(PublicKey);
+
+impl TryFrom<String> for VerifyingKey {
+    type Error = SignatureError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
+    }
+}
+
+impl From<VerifyingKey> for String {
+    fn from(value: VerifyingKey) -> Self {
+        value.0.to_string()
+    }
+}
+
+impl FromStr for VerifyingKey {
+    type Err = SignatureError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let public_key =
+            PublicKey::from_str(s).map_err(|error| Error::CreateVerifyingKey(error.into()))?;
+        Ok(Self(public_key))
+    }
+}
+
+impl super::Verifier for VerifyingKey {
+    fn from_slice(slice: &[u8]) -> Result<Self, SignatureError> {
+        let public_key = PublicKey::from_slice(slice)
+            .map_err(|error| Error::CreateVerifyingKey(error.into()))?;
+        Ok(Self(public_key))
+    }
+
+    fn verify<T: Serialize>(
+        &self,
+        message: &T,
+        signature: &Signature,
+    ) -> Result<bool, SignatureError> {
+        if signature.scheme != SignatureScheme::Secp256k1 {
+            return Err(Error::InvalidSignatureScheme)?;
+        }
+
+        let secp = &SECP256K1_VERIFY;
+        let message_bytes =
+            bincode::serialize(message).map_err(|error| Error::Verify(error.into()))?;
+        let digest = Sha256::digest(message_bytes);
+        let msg =
+            Message::from_digest_slice(&digest).map_err(|error| Error::Verify(error.into()))?;
+        let sig = EcdsaSignature::from_compact(&signature.bytes)
+            .map_err(|error| Error::Verify(error.into()))?;
+
+        match secp.verify_ecdsa(&msg, &sig, &self.0) {
+            Ok(()) => Ok(true),
+            Err(_error) => Ok(false),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Failed to create a signing key: {0}")]
+    CreateSigningKey(ErrorKind),
+    #[error("Failed to sign the message: {0}")]
+    Sign(ErrorKind),
+    #[error("Failed to create a verifying key: {0}")]
+    CreateVerifyingKey(ErrorKind),
+    #[error("Failed to verify the message: {0}")]
+    Verify(ErrorKind),
+    #[error("Invalid signature scheme")]
+    InvalidSignatureScheme,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ErrorKind {
+    #[error("{0}")]
+    Secp256k1(#[from] secp256k1::Error),
+    #[error("{0}")]
+    Bincode(#[from] bincode::Error),
+}

--- a/crates/signature/src/ecdsa.rs
+++ b/crates/signature/src/ecdsa.rs
@@ -31,11 +31,6 @@ impl super::Signer for SigningKey {
         Ok(Self(private_key))
     }
 
-    fn verifying_key(&self) -> impl crate::Verifier {
-        let secp = Secp256k1::new();
-        VerifyingKey(PublicKey::from_secret_key(&secp, &self.0))
-    }
-
     fn sign<T: Serialize>(&self, message: &T) -> Result<Signature, SignatureError> {
         let message_bytes =
             bincode::serialize(message).map_err(|error| Error::Sign(error.into()))?;
@@ -48,6 +43,13 @@ impl super::Signer for SigningKey {
             bytes: signature.to_vec(),
             scheme: SignatureScheme::Secp256k1,
         })
+    }
+}
+
+impl SigningKey {
+    pub fn verifying_key(&self) -> VerifyingKey {
+        let secp = Secp256k1::new();
+        VerifyingKey(PublicKey::from_secret_key(&secp, &self.0))
     }
 }
 

--- a/crates/signature/src/eddsa.rs
+++ b/crates/signature/src/eddsa.rs
@@ -1,0 +1,124 @@
+use crate::{Signature, SignatureError, SignatureScheme};
+use ed25519_dalek::{
+    Signature as EddsaSignature, Signer, SigningKey as PrivateKey, Verifier,
+    VerifyingKey as PublicKey,
+};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+pub struct SigningKey(PrivateKey);
+
+impl FromStr for SigningKey {
+    type Err = SignatureError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = hex::decode(s).map_err(|error| Error::CreateSigningKey(error.into()))?;
+        let secret_key = PrivateKey::try_from(bytes.as_slice())
+            .map_err(|error| Error::CreateSigningKey(error.into()))?;
+        Ok(Self(secret_key))
+    }
+}
+
+impl super::Signer for SigningKey {
+    fn from_slice(slice: &[u8]) -> Result<Self, SignatureError> {
+        let secret_key =
+            PrivateKey::try_from(slice).map_err(|error| Error::CreateSigningKey(error.into()))?;
+        Ok(Self(secret_key))
+    }
+
+    fn verifying_key(&self) -> impl crate::Verifier {
+        VerifyingKey(PublicKey::from(&self.0))
+    }
+
+    fn sign<T: Serialize>(&self, message: &T) -> Result<Signature, SignatureError> {
+        let message_bytes =
+            bincode::serialize(message).map_err(|error| Error::Sign(error.into()))?;
+        let signature = self.0.sign(&message_bytes);
+        Ok(Signature {
+            bytes: signature.to_vec(),
+            scheme: SignatureScheme::Ed25519,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "String")]
+#[serde(into = "String")]
+pub struct VerifyingKey(PublicKey);
+
+impl TryFrom<String> for VerifyingKey {
+    type Error = SignatureError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
+    }
+}
+
+impl From<VerifyingKey> for String {
+    fn from(value: VerifyingKey) -> Self {
+        hex::encode(value.0.as_bytes())
+    }
+}
+
+impl FromStr for VerifyingKey {
+    type Err = SignatureError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = hex::decode(s).map_err(|error| Error::CreateVerifyingKey(error.into()))?;
+        let public_key = PublicKey::try_from(bytes.as_slice())
+            .map_err(|error| Error::CreateVerifyingKey(error.into()))?;
+        Ok(Self(public_key))
+    }
+}
+
+impl super::Verifier for VerifyingKey {
+    fn from_slice(slice: &[u8]) -> Result<Self, SignatureError> {
+        let public_key =
+            PublicKey::try_from(slice).map_err(|error| Error::CreateVerifyingKey(error.into()))?;
+        Ok(Self(public_key))
+    }
+
+    fn verify<T: Serialize>(
+        &self,
+        message: &T,
+        signature: &Signature,
+    ) -> Result<bool, SignatureError> {
+        if signature.scheme != SignatureScheme::Ed25519 {
+            return Err(Error::InvalidSignatureScheme)?;
+        }
+
+        let message_bytes =
+            bincode::serialize(message).map_err(|error| Error::Verify(error.into()))?;
+        let signature = EddsaSignature::from_slice(&signature.bytes)
+            .map_err(|error| Error::Verify(error.into()))?;
+
+        match self.0.verify(&message_bytes, &signature) {
+            Ok(()) => Ok(true),
+            Err(_error) => Ok(false),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Failed to create a signing key: {0}")]
+    CreateSigningKey(ErrorKind),
+    #[error("Failed to sign the message: {0}")]
+    Sign(ErrorKind),
+    #[error("Failed to create a verifying key: {0}")]
+    CreateVerifyingKey(ErrorKind),
+    #[error("Failed to verify the message: {0}")]
+    Verify(ErrorKind),
+    #[error("Invalid signature scheme")]
+    InvalidSignatureScheme,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ErrorKind {
+    #[error("{0}")]
+    Ed25519(#[from] ed25519_dalek::ed25519::Error),
+    #[error("{0}")]
+    Hex(#[from] hex::FromHexError),
+    #[error("{0}")]
+    Bincode(#[from] bincode::Error),
+}

--- a/crates/signature/src/eddsa.rs
+++ b/crates/signature/src/eddsa.rs
@@ -26,10 +26,6 @@ impl super::Signer for SigningKey {
         Ok(Self(secret_key))
     }
 
-    fn verifying_key(&self) -> impl crate::Verifier {
-        VerifyingKey(PublicKey::from(&self.0))
-    }
-
     fn sign<T: Serialize>(&self, message: &T) -> Result<Signature, SignatureError> {
         let message_bytes =
             bincode::serialize(message).map_err(|error| Error::Sign(error.into()))?;
@@ -38,6 +34,12 @@ impl super::Signer for SigningKey {
             bytes: signature.to_vec(),
             scheme: SignatureScheme::Ed25519,
         })
+    }
+}
+
+impl SigningKey {
+    fn verifying_key(&self) -> VerifyingKey {
+        VerifyingKey(PublicKey::from(&self.0))
     }
 }
 

--- a/crates/signature/src/error.rs
+++ b/crates/signature/src/error.rs
@@ -1,9 +1,9 @@
 #[derive(Debug, thiserror::Error)]
 pub enum SignatureError {
-    // #[cfg(any(feature = "default", feature = "secp256k1"))]
+    #[cfg(any(feature = "default", feature = "secp256k1"))]
     #[error("{0}")]
     Ecdsa(#[from] crate::ecdsa::Error),
-    // #[cfg(feature = "ed25519")]
+    #[cfg(feature = "ed25519")]
     #[error("{0}")]
     Eddsa(#[from] crate::eddsa::Error),
 }

--- a/crates/signature/src/error.rs
+++ b/crates/signature/src/error.rs
@@ -1,17 +1,9 @@
 #[derive(Debug, thiserror::Error)]
 pub enum SignatureError {
-    #[error("Invalid key length. Expected:{expected}, Got:{actual}")]
-    InvalidKeyLength { expected: usize, actual: usize },
-    #[error("Invalid signature length")]
-    InvalidSignatureLength,
-    #[error("Signature verification failed")]
-    VerificationFailed,
-    #[error("Signature scheme does not match")]
-    SchemeDoesNotMatch,
-    #[error("Fail to decode hex string: {0}")]
-    HexDecodeError(#[from] hex::FromHexError),
-    #[error("Ed25519 library error: {0}")]
-    Ed25519LibError(#[from] ed25519_dalek::SignatureError),
-    #[error("Secp256k1 library error: {0}")]
-    Secp256k1LibError(#[from] secp256k1::Error),
+    // #[cfg(any(feature = "default", feature = "secp256k1"))]
+    #[error("{0}")]
+    Ecdsa(#[from] crate::ecdsa::Error),
+    // #[cfg(feature = "ed25519")]
+    #[error("{0}")]
+    Eddsa(#[from] crate::eddsa::Error),
 }

--- a/crates/signature/src/lib.rs
+++ b/crates/signature/src/lib.rs
@@ -16,8 +16,6 @@ use std::str::FromStr;
 pub trait Signer: FromStr<Err = SignatureError> + Sized {
     fn from_slice(slice: &[u8]) -> Result<Self, SignatureError>;
 
-    fn verifying_key(&self) -> impl Verifier;
-
     fn sign<T: Serialize>(&self, message: &T) -> Result<Signature, SignatureError>;
 }
 

--- a/crates/signature/src/lib.rs
+++ b/crates/signature/src/lib.rs
@@ -1,13 +1,13 @@
-// #[cfg(feature = "secp256k1")]
+#[cfg(feature = "secp256k1")]
 pub mod ecdsa;
-// #[cfg(feature = "ed25519")]
+#[cfg(feature = "ed25519")]
 pub mod eddsa;
 mod error;
 
-// #[cfg(feature = "secp256k1")]
-// pub use ecdsa::{SigningKey, VerifyingKey};
-// #[cfg(any(feature = "default", feature = "ed25519"))]
-// pub use eddsa::{SigningKey, VerifyingKey};
+#[cfg(feature = "secp256k1")]
+pub use ecdsa::{SigningKey, VerifyingKey};
+#[cfg(feature = "ed25519")]
+pub use eddsa::{SigningKey, VerifyingKey};
 pub use error::SignatureError;
 
 use serde::{Deserialize, Serialize};

--- a/crates/signature/src/lib.rs
+++ b/crates/signature/src/lib.rs
@@ -1,338 +1,158 @@
-#[cfg(feature = "ed25519")]
-use ed25519::Verifier;
-#[cfg(feature = "ed25519")]
-use ed25519_dalek as ed25519;
-#[cfg(feature = "secp256k1")]
-use secp256k1::{ecdsa::Signature as SecpSig, Message, Secp256k1};
+// #[cfg(feature = "secp256k1")]
+pub mod ecdsa;
+// #[cfg(feature = "ed25519")]
+pub mod eddsa;
+mod error;
 
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use std::sync::LazyLock;
-use tiny_keccak::{Hasher, Keccak};
-
-pub mod error;
+// #[cfg(feature = "secp256k1")]
+// pub use ecdsa::{SigningKey, VerifyingKey};
+// #[cfg(any(feature = "default", feature = "ed25519"))]
+// pub use eddsa::{SigningKey, VerifyingKey};
 pub use error::SignatureError;
 
-static SECP256K1_SIGNING: LazyLock<Secp256k1<secp256k1::SignOnly>> =
-    LazyLock::new(Secp256k1::signing_only);
-static SECP256K1_VERIFY: LazyLock<Secp256k1<secp256k1::VerifyOnly>> =
-    LazyLock::new(Secp256k1::verification_only);
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
-#[derive(PartialEq, Serialize, Deserialize)]
+pub trait Signer: FromStr<Err = SignatureError> + Sized {
+    fn from_slice(slice: &[u8]) -> Result<Self, SignatureError>;
+
+    fn verifying_key(&self) -> impl Verifier;
+
+    fn sign<T: Serialize>(&self, message: &T) -> Result<Signature, SignatureError>;
+}
+
+pub trait Verifier:
+    FromStr<Err = SignatureError> + Sized + Deserialize<'static> + Serialize
+{
+    fn from_slice(slice: &[u8]) -> Result<Self, SignatureError>;
+
+    fn verify<T: Serialize>(
+        &self,
+        message: &T,
+        signature: &Signature,
+    ) -> Result<bool, SignatureError>;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum SignatureScheme {
-    #[cfg(feature = "ed25519")]
     Ed25519,
-    #[cfg(feature = "secp256k1")]
     Secp256k1,
 }
 
-#[derive(Clone, Debug)]
-pub enum SigningKey {
-    #[cfg(feature = "ed25519")]
-    Ed25519(ed25519::SigningKey),
-    #[cfg(feature = "secp256k1")]
-    Secp256k1(secp256k1::SecretKey),
-}
-
-#[derive(Serialize, Deserialize)]
-pub enum VerifyingKey {
-    #[cfg(feature = "ed25519")]
-    Ed25519(ed25519::VerifyingKey),
-    #[cfg(feature = "secp256k1")]
-    Secp256k1(secp256k1::PublicKey),
-}
-
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Signature {
     pub bytes: Vec<u8>,
     pub scheme: SignatureScheme,
 }
 
-impl Signature {
-    pub const BYTE_SIZE: usize = 64;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use hex::FromHex;
 
-    pub fn bytes(&self) -> &[u8] {
-        &self.bytes
-    }
-}
+//     /// use anvil 0 account for test in here: https://getfoundry.sh/anvil/overview/
+//     /// address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+//     /// private_key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
-pub fn default_scheme() -> SignatureScheme {
-    #[cfg(all(feature = "secp256k1", not(feature = "ed25519")))]
-    {
-        SignatureScheme::Secp256k1
-    }
-    #[cfg(all(feature = "ed25519", not(feature = "secp256k1")))]
-    {
-        SignatureScheme::Ed25519
-    }
-    #[cfg(all(feature = "secp256k1", feature = "ed25519"))]
-    {
-        SignatureScheme::Secp256k1
-    }
-    #[cfg(not(any(feature = "secp256k1", feature = "ed25519")))]
-    {
-        compile_error!("At least one signature scheme feature must be enabled");
-    }
-}
+//     #[test]
+//     #[cfg(feature = "secp256k1")]
+//     fn test_secp256k1_address_from_anvil_acc0_pk() {
+//         let anvil_acc0_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+//         let signing_key = SigningKey::from_str(&anvil_acc0_key).unwrap();
+//         let sk = secp256k1::SecretKey::from_slice(&anvil_acc0_key).unwrap();
+//         let pub_key = secp256k1::PublicKey::from_secret_key(&secp, &sk);
 
-impl SigningKey {
-    pub fn from_bytes(scheme: SignatureScheme, bytes: &[u8]) -> Result<Self, SignatureError> {
-        match scheme {
-            #[cfg(feature = "ed25519")]
-            SignatureScheme::Ed25519 => {
-                let secret_key: &[u8; ed25519::SECRET_KEY_LENGTH] =
-                    bytes
-                        .try_into()
-                        .map_err(|_| SignatureError::InvalidKeyLength {
-                            expected: ed25519::SECRET_KEY_LENGTH,
-                            actual: bytes.len(),
-                        })?;
-                let signing_key = ed25519::SigningKey::from_bytes(secret_key);
-                Ok(SigningKey::Ed25519(signing_key))
-            }
-            #[cfg(feature = "secp256k1")]
-            SignatureScheme::Secp256k1 => {
-                let secret_key = secp256k1::SecretKey::from_slice(bytes)?;
-                Ok(Self::Secp256k1(secret_key))
-            }
-        }
-    }
+//         let address = address_from_pubkey(&VerifyingKey::Secp256k1(pub_key)).unwrap();
+//         let address = hex::encode(address);
+//         assert_eq!(
+//             address,
+//             "f39Fd6e51aad88F6F4ce6aB8827279cffFb92266".to_lowercase()
+//         );
+//         print!("address expected  : \"f39Fd6e51aad88F6F4ce6aB8827279cffFb92266\"\naddress calculated: {:?}", address);
+//     }
 
-    pub fn from_bytes_default(bytes: &[u8]) -> Result<Self, SignatureError> {
-        Self::from_bytes(default_scheme(), bytes)
-    }
-}
+//     #[test]
+//     #[cfg(feature = "secp256k1")]
+//     fn test_secp256k1_sign_and_verify() {
+//         let anvil_acc0_key: [u8; 32] = <[u8; 32]>::from_hex(
+//             "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+//         )
+//         .unwrap();
+//         let secp = Secp256k1::new();
+//         let sk = secp256k1::SecretKey::from_slice(&anvil_acc0_key).unwrap();
+//         let signing_key =
+//             SigningKey::from_bytes(SignatureScheme::Secp256k1, &anvil_acc0_key).unwrap();
+//         let pub_key = secp256k1::PublicKey::from_secret_key(&secp, &sk);
+//         let msg = b"Hello World";
 
-impl VerifyingKey {
-    pub fn from_bytes(scheme: SignatureScheme, bytes: &[u8]) -> Result<Self, SignatureError> {
-        match scheme {
-            #[cfg(feature = "ed25519")]
-            SignatureScheme::Ed25519 => {
-                let pub_key_arr: &[u8; ed25519::PUBLIC_KEY_LENGTH] =
-                    bytes
-                        .try_into()
-                        .map_err(|_| SignatureError::InvalidKeyLength {
-                            expected: ed25519::PUBLIC_KEY_LENGTH,
-                            actual: bytes.len(),
-                        })?;
-                let verifying_key = ed25519::VerifyingKey::from_bytes(pub_key_arr)?;
-                Ok(VerifyingKey::Ed25519(verifying_key))
-            }
-            #[cfg(feature = "secp256k1")]
-            SignatureScheme::Secp256k1 => {
-                let pub_key = secp256k1::PublicKey::from_slice(bytes)?;
-                Ok(VerifyingKey::Secp256k1(pub_key))
-            }
-        }
-    }
+//         let signature = sign(&signing_key, msg).unwrap();
+//         let res = verify(&VerifyingKey::Secp256k1(pub_key), msg, &signature);
+//         assert!(res.is_ok())
+//     }
 
-    pub fn from_signing_key(signing_key: &SigningKey) -> Result<Self, SignatureError> {
-        match &signing_key {
-            #[cfg(feature = "ed25519")]
-            SigningKey::Ed25519(key) => Ok(VerifyingKey::Ed25519(key.verifying_key())),
-            #[cfg(feature = "secp256k1")]
-            SigningKey::Secp256k1(key) => {
-                let pub_key = secp256k1::PublicKey::from_secret_key(&SECP256K1_SIGNING, key);
-                Ok(VerifyingKey::Secp256k1(pub_key))
-            }
-        }
-    }
+//     /// made key pair using `solana-keygen new --no-passphrase`
+//     ///
+//     /// [
+//     ///   144,  45, 220,  66,  89, 201,   7, 239,
+//     ///    86, 173, 155, 227,  31, 102,  64, 151,
+//     ///   142, 184, 211, 146, 225, 143, 253, 224,
+//     ///   165, 105, 222, 216,   4, 223,  35, 225,
+//     ///
+//     ///   104, 129, 238,  30, 109,  80,  35,  40,
+//     ///   222, 122, 189, 203, 126, 168,  28, 216,
+//     ///   229, 110, 167,  57, 192, 114, 219, 225,
+//     ///   233, 104,   3,  71,   9, 159, 103, 127
+//     /// ]
+//     ///
+//     /// first 32 bytes for secret key,
+//     /// second 32 bytes for public key.
 
-    pub fn from_bytes_default(bytes: &[u8]) -> Result<Self, SignatureError> {
-        Self::from_bytes(default_scheme(), bytes)
-    }
-}
+//     #[test]
+//     #[cfg(feature = "ed25519")]
+//     fn test_ed25519_get_public_key_from_private_key() {
+//         let private_key: [u8; 32] = [
+//             144, 45, 220, 66, 89, 201, 7, 239, 86, 173, 155, 227, 31, 102, 64, 151, 142, 184, 211,
+//             146, 225, 143, 253, 224, 165, 105, 222, 216, 4, 223, 35, 225,
+//         ];
+//         let signing_key = SigningKey::from_bytes(&private_key).unwrap();
+//         let public_key = match signing_key {
+//             SigningKey::Ed25519(key) => key.verifying_key().to_bytes(),
+//             _ => panic!("Invalid Signing key type"),
+//         };
 
-pub fn sign(signing_key: &SigningKey, msg: &[u8]) -> Result<Signature, SignatureError> {
-    match signing_key {
-        #[cfg(feature = "ed25519")]
-        SigningKey::Ed25519(key) => {
-            use ed25519::Signer;
-            let signature = key.sign(msg);
-            Ok(Signature {
-                bytes: signature.to_bytes().to_vec(),
-                scheme: SignatureScheme::Ed25519,
-            })
-        }
+//         let expected_pub_key: String = hex::encode([
+//             104, 129, 238, 30, 109, 80, 35, 40, 222, 122, 189, 203, 126, 168, 28, 216, 229, 110,
+//             167, 57, 192, 114, 219, 225, 233, 104, 3, 71, 9, 159, 103, 127,
+//         ]);
 
-        #[cfg(feature = "secp256k1")]
-        SigningKey::Secp256k1(key) => {
-            let msg_hash = Sha256::digest(msg);
-            let message = Message::from_digest_slice(msg_hash.as_slice())?;
-            let secp256k1 = &SECP256K1_SIGNING;
-            let signature = secp256k1.sign_ecdsa(&message, &key).serialize_compact();
-            Ok(Signature {
-                bytes: signature.to_vec(),
-                scheme: SignatureScheme::Secp256k1,
-            })
-        }
-    }
-}
+//         let calculated_pub_key = hex::encode(public_key);
 
-pub fn verify(
-    verifying_key: &VerifyingKey,
-    msg: &[u8],
-    signature: &Signature,
-) -> Result<(), SignatureError> {
-    match (verifying_key, &signature.scheme) {
-        #[cfg(feature = "ed25519")]
-        (VerifyingKey::Ed25519(key), SignatureScheme::Ed25519) => {
-            let sig_bytes: [u8; ed25519::SIGNATURE_LENGTH] = signature
-                .bytes
-                .as_slice()
-                .try_into()
-                .map_err(|_| SignatureError::InvalidSignatureLength)?;
+//         print!(
+//             "expected  : {:?}\ncalculated: {:?}",
+//             expected_pub_key, calculated_pub_key
+//         );
+//         assert_eq!(expected_pub_key, calculated_pub_key);
+//     }
 
-            let sig = ed25519::Signature::from_bytes(&sig_bytes);
-            key.verify(msg, &sig)?;
-            Ok(())
-        }
-        #[cfg(feature = "secp256k1")]
-        (VerifyingKey::Secp256k1(key), SignatureScheme::Secp256k1) => {
-            let secp = &SECP256K1_VERIFY;
-            let digest = Sha256::digest(msg);
-            let msg = Message::from_digest_slice(&digest)?;
-            let sig = SecpSig::from_compact(&signature.bytes)?;
-            secp.verify_ecdsa(&msg, &sig, key)?;
-            Ok(())
-        }
-        _ => Err(SignatureError::SchemeDoesNotMatch),
-    }
-}
+//     #[test]
+//     #[cfg(feature = "ed25519")]
+//     fn test_ed25519_sign_and_verify() {
+//         let private_key: [u8; 32] = [
+//             144, 45, 220, 66, 89, 201, 7, 239, 86, 173, 155, 227, 31, 102, 64, 151, 142, 184, 211,
+//             146, 225, 143, 253, 224, 165, 105, 222, 216, 4, 223, 35, 225,
+//         ];
+//         let signing_key = SigningKey::from_bytes(SignatureScheme::Ed25519, &private_key).unwrap();
+//         let verifying_key = match &signing_key {
+//             SigningKey::Ed25519(key) => key.verifying_key(),
+//             _ => panic!("Invalid Signing key type"),
+//         };
+//         let msg = b"Hello World";
 
-pub fn address_from_pubkey(verifying_key: &VerifyingKey) -> Result<Vec<u8>, SignatureError> {
-    match verifying_key {
-        #[cfg(feature = "ed25519")]
-        VerifyingKey::Ed25519(key) => Ok(key.to_bytes().to_vec()),
-        #[cfg(feature = "secp256k1")]
-        VerifyingKey::Secp256k1(key) => {
-            let public_key = key.serialize_uncompressed();
+//         let signature = sign(&signing_key, msg).unwrap();
+//         let res = verify(&VerifyingKey::Ed25519(verifying_key), msg, &signature);
 
-            let mut hasher = Keccak::v256();
-            // Remove the 0x04 prefix byte from uncompressed public key
-            hasher.update(&public_key[1..]);
-            let mut hash = [0u8; 32];
-            hasher.finalize(&mut hash);
+//         assert!(res.is_ok())
+//     }
 
-            let mut address = [0u8; 20];
-            address.copy_from_slice(&hash[12..]);
-
-            Ok(address.to_vec())
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use hex::FromHex;
-
-    /// use anvil 0 account for test in here: https://getfoundry.sh/anvil/overview/
-    /// address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-    /// private_key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-
-    #[test]
-    #[cfg(feature = "secp256k1")]
-    fn test_secp256k1_address_from_anvil_acc0_pk() {
-        let anvil_acc0_key: [u8; 32] = <[u8; 32]>::from_hex(
-            "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-        )
-        .unwrap();
-        let secp = Secp256k1::new();
-        let sk = secp256k1::SecretKey::from_slice(&anvil_acc0_key).unwrap();
-        let pub_key = secp256k1::PublicKey::from_secret_key(&secp, &sk);
-
-        let address = address_from_pubkey(&VerifyingKey::Secp256k1(pub_key)).unwrap();
-        let address = hex::encode(address);
-        assert_eq!(
-            address,
-            "f39Fd6e51aad88F6F4ce6aB8827279cffFb92266".to_lowercase()
-        );
-        print!("address expected  : \"f39Fd6e51aad88F6F4ce6aB8827279cffFb92266\"\naddress calculated: {:?}", address);
-    }
-
-    #[test]
-    #[cfg(feature = "secp256k1")]
-    fn test_secp256k1_sign_and_verify() {
-        let anvil_acc0_key: [u8; 32] = <[u8; 32]>::from_hex(
-            "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-        )
-        .unwrap();
-        let secp = Secp256k1::new();
-        let sk = secp256k1::SecretKey::from_slice(&anvil_acc0_key).unwrap();
-        let signing_key =
-            SigningKey::from_bytes(SignatureScheme::Secp256k1, &anvil_acc0_key).unwrap();
-        let pub_key = secp256k1::PublicKey::from_secret_key(&secp, &sk);
-        let msg = b"Hello World";
-
-        let signature = sign(&signing_key, msg).unwrap();
-        let res = verify(&VerifyingKey::Secp256k1(pub_key), msg, &signature);
-        assert!(res.is_ok())
-    }
-
-    /// made key pair using `solana-keygen new --no-passphrase`
-    ///
-    /// [
-    ///   144,  45, 220,  66,  89, 201,   7, 239,
-    ///    86, 173, 155, 227,  31, 102,  64, 151,
-    ///   142, 184, 211, 146, 225, 143, 253, 224,
-    ///   165, 105, 222, 216,   4, 223,  35, 225,
-    ///
-    ///   104, 129, 238,  30, 109,  80,  35,  40,
-    ///   222, 122, 189, 203, 126, 168,  28, 216,
-    ///   229, 110, 167,  57, 192, 114, 219, 225,
-    ///   233, 104,   3,  71,   9, 159, 103, 127
-    /// ]
-    ///
-    /// first 32 bytes for secret key,
-    /// second 32 bytes for public key.
-
-    #[test]
-    #[cfg(feature = "ed25519")]
-    fn test_ed25519_get_public_key_from_private_key() {
-        let private_key: [u8; 32] = [
-            144, 45, 220, 66, 89, 201, 7, 239, 86, 173, 155, 227, 31, 102, 64, 151, 142, 184, 211,
-            146, 225, 143, 253, 224, 165, 105, 222, 216, 4, 223, 35, 225,
-        ];
-        let signing_key = SigningKey::from_bytes(SignatureScheme::Ed25519, &private_key).unwrap();
-        let public_key = match signing_key {
-            SigningKey::Ed25519(key) => key.verifying_key().to_bytes(),
-            _ => panic!("Invalid Signing key type"),
-        };
-
-        let expected_pub_key: String = hex::encode([
-            104, 129, 238, 30, 109, 80, 35, 40, 222, 122, 189, 203, 126, 168, 28, 216, 229, 110,
-            167, 57, 192, 114, 219, 225, 233, 104, 3, 71, 9, 159, 103, 127,
-        ]);
-
-        let calculated_pub_key = hex::encode(public_key);
-
-        print!(
-            "expected  : {:?}\ncalculated: {:?}",
-            expected_pub_key, calculated_pub_key
-        );
-        assert_eq!(expected_pub_key, calculated_pub_key);
-    }
-
-    #[test]
-    #[cfg(feature = "ed25519")]
-    fn test_ed25519_sign_and_verify() {
-        let private_key: [u8; 32] = [
-            144, 45, 220, 66, 89, 201, 7, 239, 86, 173, 155, 227, 31, 102, 64, 151, 142, 184, 211,
-            146, 225, 143, 253, 224, 165, 105, 222, 216, 4, 223, 35, 225,
-        ];
-        let signing_key = SigningKey::from_bytes(SignatureScheme::Ed25519, &private_key).unwrap();
-        let verifying_key = match &signing_key {
-            SigningKey::Ed25519(key) => key.verifying_key(),
-            _ => panic!("Invalid Signing key type"),
-        };
-        let msg = b"Hello World";
-
-        let signature = sign(&signing_key, msg).unwrap();
-        let res = verify(&VerifyingKey::Ed25519(verifying_key), msg, &signature);
-
-        assert!(res.is_ok())
-    }
-
-    // TODO: Add negative (failure) test cases as well
-}
+//     // TODO: Add negative (failure) test cases as well
+// }


### PR DESCRIPTION
- All APIs are exposed through `Signer` and `Verifier` traits.
- Additional trait bound to support seamless conversion from/to hexadecimal String.