### PR TITLE
fix: while dev is made it's easier to use those dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ jwt.hex
 Cargo.toml.bak
 
 .rules
+
+mojave-full-node
+mojave-sequencer

--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
 #!/usr/bin/env just --justfile
 
+current-dir := `pwd`
+
 # List all of the available commands.
 default:
 	just --list
@@ -11,14 +13,16 @@ node:
     export $(cat .env | xargs) && \
     cargo run --release --bin mojave-full-node init \
         --network ./test_data/genesis.json \
-        --sequencer.address http://0.0.0.0:1739
+        --sequencer.address http://0.0.0.0:1739 \
+        --datadir {{current-dir}}/mojave-full-node
 
 sequencer:
     export $(cat .env | xargs) && \
     cargo run --release --bin mojave-sequencer init \
         --network ./test_data/genesis.json \
         --http.port 1739 \
-        --full_node.addresses http://0.0.0.0:8545
+        --full_node.addresses http://0.0.0.0:8545 \
+        --datadir {{current-dir}}/mojave-sequencer
 
 generate-key-pair:
 	cargo build --bin mojave


### PR DESCRIPTION
In order to be sure the full-node and the sequencer in local do not use the same datadir in the just file we have to set it