### PR TITLE
feat: adapt builder pattern to mojave client

### DIFF
--- a/cmd/sequencer/src/main.rs
+++ b/cmd/sequencer/src/main.rs
@@ -37,8 +37,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             let mojave_client = MojaveClient::builder()
                 .private_key(sequencer_options.private_key)
-                .full_node_url(&sequencer_options.full_node_addresses)
-                .prover_url(&[sequencer_options.prover_address])
+                .full_node_urls(&sequencer_options.full_node_addresses)
+                .prover_urls(&[sequencer_options.prover_address])
                 .build()
                 .unwrap_or_else(|error| {
                     tracing::error!("Failed to build the client: {}", error);

--- a/cmd/sequencer/src/main.rs
+++ b/cmd/sequencer/src/main.rs
@@ -2,7 +2,7 @@ pub mod cli;
 
 use crate::cli::Command;
 use mojave_block_producer::{BlockProducer, BlockProducerContext};
-use mojave_client::MojaveClient;
+use mojave_client::{MojaveClient, types::Strategy};
 use mojave_node_lib::types::MojaveNode;
 use std::{error::Error, time::Duration};
 
@@ -50,6 +50,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     match block_producer.build_block().await {
                         Ok(block) => mojave_client
                             .request()
+                            .strategy(Strategy::Race)
                             .send_broadcast_block(&block)
                             .await
                             .unwrap_or_else(|error| tracing::error!("{}", error)),

--- a/cmd/sequencer/src/main.rs
+++ b/cmd/sequencer/src/main.rs
@@ -46,7 +46,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             let mojave_client = MojaveClient::builder()
                 .private_key(&sequencer_options.private_key)
-                .full_node_urls(&full_node_urls)
                 .build()
                 .unwrap(); // TODO: Handle error
 
@@ -54,6 +53,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 loop {
                     match block_producer.build_block().await {
                         Ok(block) => mojave_client
+                            .request_builder()
+                            .full_node_urls(&full_node_urls)
                             .send_broadcast_block(&block)
                             .await
                             .unwrap_or_else(|error| tracing::error!("{}", error)),

--- a/cmd/sequencer/src/main.rs
+++ b/cmd/sequencer/src/main.rs
@@ -47,7 +47,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let mojave_client = MojaveClient::builder()
                 .private_key(&sequencer_options.private_key)
                 .build()
-                .unwrap(); // TODO: Handle error
+                .unwrap_or_else(|error| {
+                    panic!("Failed to build the client: {}", error);
+                });
 
             tokio::spawn(async move {
                 loop {

--- a/cmd/sequencer/src/main.rs
+++ b/cmd/sequencer/src/main.rs
@@ -46,9 +46,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             let mojave_client = MojaveClient::builder()
                 .private_key(&sequencer_options.private_key)
+                .unwrap_or_else(|error| {
+                    tracing::error!("Failed to parse private key: {}", error);
+                    std::process::exit(1);
+                })
                 .build()
                 .unwrap_or_else(|error| {
-                    panic!("Failed to build the client: {}", error);
+                    tracing::error!("Failed to build the client: {}", error);
+                    std::process::exit(1);
                 });
 
             tokio::spawn(async move {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -12,7 +12,7 @@ use futures::{
     future::{Fuse, select_ok},
 };
 use mojave_signature::{Signature, Signer, SigningKey};
-use reqwest::{ClientBuilder, Url};
+use reqwest::Url;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use std::{pin::Pin, str::FromStr, sync::Arc, time::Duration};

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -23,26 +23,26 @@ const MAX_DELAY: Duration = Duration::from_secs(30);
 
 #[derive(Default)]
 pub struct MojaveClientBuilder {
-    sequencer_url: Option<Vec<String>>,
-    full_node_url: Option<Vec<String>>,
-    prover_url: Option<Vec<String>>,
+    sequencer_urls: Option<Vec<String>>,
+    full_node_urls: Option<Vec<String>>,
+    prover_urls: Option<Vec<String>>,
     private_key: Option<String>,
     timeout: Option<Duration>,
 }
 
 impl MojaveClientBuilder {
-    pub fn sequencer_url(mut self, sequencer_url: &[String]) -> Self {
-        self.sequencer_url = Some(sequencer_url.to_owned());
+    pub fn sequencer_urls(mut self, sequencer_urls: &[String]) -> Self {
+        self.sequencer_urls = Some(sequencer_urls.to_owned());
         self
     }
 
-    pub fn full_node_url(mut self, full_node_url: &[String]) -> Self {
-        self.full_node_url = Some(full_node_url.to_owned());
+    pub fn full_node_urls(mut self, full_node_urls: &[String]) -> Self {
+        self.full_node_urls = Some(full_node_urls.to_owned());
         self
     }
 
-    pub fn prover_url(mut self, prover_url: &[String]) -> Self {
-        self.prover_url = Some(prover_url.to_owned());
+    pub fn prover_urls(mut self, prover_urls: &[String]) -> Self {
+        self.prover_urls = Some(prover_urls.to_owned());
         self
     }
 
@@ -63,20 +63,20 @@ impl MojaveClientBuilder {
     }
 
     pub fn build(mut self) -> Result<MojaveClient, MojaveClientError> {
-        let sequencer_url = self.sequencer_url.take();
+        let sequencer_urls = self.sequencer_urls.take();
 
-        let full_node_url = self.full_node_url.take();
+        let full_node_urls = self.full_node_urls.take();
 
-        let prover_url = self.prover_url.take();
+        let prover_urls = self.prover_urls.take();
 
         let private_key = self.private_key.take();
 
         let timeout = self.timeout.take();
 
         MojaveClient::new(
-            sequencer_url,
-            full_node_url,
-            prover_url,
+            sequencer_urls,
+            full_node_urls,
+            prover_urls,
             private_key,
             timeout,
         )
@@ -90,9 +90,9 @@ pub struct MojaveClient {
 
 struct MojaveClientInner {
     client: reqwest::Client,
-    sequencer_url: Option<Vec<Url>>,
-    full_node_url: Option<Vec<Url>>,
-    prover_url: Option<Vec<Url>>,
+    sequencer_urls: Option<Vec<Url>>,
+    full_node_urls: Option<Vec<Url>>,
+    prover_urls: Option<Vec<Url>>,
     signing_key: Option<SigningKey>,
 }
 
@@ -116,9 +116,9 @@ impl MojaveClient {
     }
 
     pub fn new(
-        sequencer_url: Option<Vec<String>>,
-        full_node_url: Option<Vec<String>>,
-        prover_url: Option<Vec<String>>,
+        sequencer_urls: Option<Vec<String>>,
+        full_node_urls: Option<Vec<String>>,
+        prover_urls: Option<Vec<String>>,
         private_key: Option<String>,
         timeout: Option<Duration>,
     ) -> Result<Self, MojaveClientError> {
@@ -131,9 +131,9 @@ impl MojaveClient {
         let client = MojaveClient {
             inner: Arc::new(MojaveClientInner {
                 client: http_client.build()?,
-                sequencer_url: Self::parse_urls(sequencer_url)?,
-                full_node_url: Self::parse_urls(full_node_url)?,
-                prover_url: Self::parse_urls(prover_url)?,
+                sequencer_urls: Self::parse_urls(sequencer_urls)?,
+                full_node_urls: Self::parse_urls(full_node_urls)?,
+                prover_urls: Self::parse_urls(prover_urls)?,
                 signing_key: match private_key {
                     Some(private_key) => Some(
                         SigningKey::from_str(&private_key)
@@ -371,7 +371,7 @@ impl<'a> Request<'a> {
             None => self
                 .client
                 .inner
-                .full_node_url
+                .full_node_urls
                 .as_ref()
                 .ok_or(MojaveClientError::MissingFullNodeUrls)?,
         };
@@ -398,7 +398,7 @@ impl<'a> Request<'a> {
             None => self
                 .client
                 .inner
-                .prover_url
+                .prover_urls
                 .as_ref()
                 .ok_or(MojaveClientError::MissingProverUrl)?,
         };
@@ -421,7 +421,7 @@ impl<'a> Request<'a> {
             None => self
                 .client
                 .inner
-                .prover_url
+                .prover_urls
                 .as_ref()
                 .ok_or(MojaveClientError::MissingProverUrl)?,
         };
@@ -444,7 +444,7 @@ impl<'a> Request<'a> {
             None => self
                 .client
                 .inner
-                .prover_url
+                .prover_urls
                 .as_ref()
                 .ok_or(MojaveClientError::MissingProverUrl)?,
         };
@@ -485,7 +485,7 @@ impl<'a> Request<'a> {
             None => self
                 .client
                 .inner
-                .sequencer_url
+                .sequencer_urls
                 .as_ref()
                 .ok_or(MojaveClientError::MissingSequencerUrl)?,
         };

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -123,7 +123,9 @@ impl MojaveClient {
         private_key: Option<String>,
         timeout: Option<Duration>,
     ) -> Result<Self, MojaveClientError> {
-        let http_client = ClientBuilder::new().timeout(timeout.unwrap_or(DEFAULT_TIMEOUT)).build()?;
+        let http_client = ClientBuilder::new()
+            .timeout(timeout.unwrap_or(DEFAULT_TIMEOUT))
+            .build()?;
 
         let client = MojaveClient {
             inner: Arc::new(MojaveClientInner {
@@ -258,10 +260,7 @@ impl MojaveClient {
     }
 
     fn is_retryable(error: &MojaveClientError) -> bool {
-        match error {
-            MojaveClientError::TimeOut => true,
-            _ => false,
-        }
+        matches!(error, MojaveClientError::TimeOut)
     }
 
     pub async fn send_request_to_url_with_retry<T>(

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -34,13 +34,10 @@ impl MojaveClientBuilder {
     }
 
     pub fn build(self) -> Result<MojaveClient, MojaveClientError> {
-        let signing_key = self
-            .signing_key
-            .ok_or(MojaveClientError::MissingSigningKey)?;
         Ok(MojaveClient {
             inner: Arc::new(MojaveClientInner {
                 client: reqwest::Client::new(),
-                signing_key: Some(signing_key),
+                signing_key: self.signing_key,
             }),
         })
     }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
     MojaveClientError,
-    types::{JobId, ProofResponse, ProverData, SignedBlock, SignedProofResponse},
+    types::{JobId, ProofResponse, ProverData, SignedBlock, SignedProofResponse, Strategy},
 };
 use ethrex_common::types::Block;
 use ethrex_rpc::{
@@ -12,210 +12,94 @@ use futures::{
     future::{Fuse, select_ok},
 };
 use mojave_signature::{Signature, Signer, SigningKey};
-use reqwest::Url;
+use reqwest::{ClientBuilder, Url};
 use serde::de::DeserializeOwned;
 use serde_json::json;
-use std::{pin::Pin, str::FromStr, sync::Arc, time::Duration};
-use tokio::time::timeout;
-
-const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(100);
-const BACKOFF_FACTOR: u32 = 2;
-const MAX_DELAY: Duration = Duration::from_secs(30);
+use std::{pin::Pin, sync::Arc, time::Duration};
 
 #[derive(Default)]
 pub struct MojaveClientBuilder {
-    signing_key: Option<SigningKey>,
+    sequencer_url: Option<Vec<String>>,
+    full_node_url: Option<Vec<String>>,
+    prover_url: Option<Vec<String>>,
+    private_key: Option<SigningKey>,
+    timeout: Option<Duration>,
 }
 
 impl MojaveClientBuilder {
-    pub fn private_key(mut self, private_key: &str) -> Result<Self, MojaveClientError> {
-        let signing_key = SigningKey::from_str(private_key)?;
-        self.signing_key = Some(signing_key);
-        Ok(self)
-    }
-
-    pub fn build(self) -> Result<MojaveClient, MojaveClientError> {
-        Ok(MojaveClient {
-            inner: Arc::new(MojaveClientInner {
-                client: reqwest::Client::new(),
-                signing_key: self.signing_key,
-            }),
-        })
-    }
-}
-
-#[derive(Debug)]
-pub struct RequestBuilder {
-    client: MojaveClient,
-    full_node_urls: Option<Vec<Url>>,
-    prover_url: Option<Url>,
-    sequencer_url: Option<Url>,
-    timeout: Option<u64>,
-    max_attempts: Option<u64>,
-}
-
-impl RequestBuilder {
-    pub fn full_node_urls(mut self, full_node_urls: &[Url]) -> Self {
-        self.full_node_urls = Some(full_node_urls.to_vec());
+    pub fn sequencer_url(mut self, sequencer_url: &[String]) -> Self {
+        self.sequencer_url = Some(sequencer_url.to_owned());
         self
     }
 
-    pub fn prover_url(mut self, prover_url: &Url) -> Self {
-        self.prover_url = Some(prover_url.clone());
+    pub fn full_node_url(mut self, full_node_url: &[String]) -> Self {
+        self.full_node_url = Some(full_node_url.to_owned());
         self
     }
 
-    pub fn sequencer_url(mut self, sequencer_url: &Url) -> Self {
-        self.sequencer_url = Some(sequencer_url.clone());
+    pub fn prover_url(mut self, prover_url: &[String]) -> Self {
+        self.prover_url = Some(prover_url.to_owned());
         self
     }
 
-    pub fn timeout(mut self, timeout: u64) -> Self {
+    pub fn private_key(mut self, private_key: SigningKey) -> Self {
+        self.private_key = Some(private_key);
+        self
+    }
+
+    /// Enables a total request timeout.
+    ///
+    /// The timeout is applied from when the request starts connecting until the
+    /// response body has finished. Also considered a total deadline.
+    ///
+    /// Default is no timeout.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
         self
     }
 
-    pub fn max_attempts(mut self, max_attempts: u64) -> Self {
-        self.max_attempts = Some(max_attempts);
-        self
-    }
+    pub fn build(mut self) -> Result<MojaveClient, MojaveClientError> {
+        let sequencer_url = self
+            .sequencer_url
+            .take()
+            .ok_or(MojaveClientError::MissingSequencerUrl)?;
 
-    pub async fn send_broadcast_block(&self, block: &Block) -> Result<(), MojaveClientError> {
-        let hash = block.hash();
-        let signing_key = self
-            .client
-            .inner
-            .signing_key
-            .as_ref()
-            .ok_or(MojaveClientError::MissingSigningKey)?;
-        let signature: Signature = signing_key.sign(&hash)?;
-        let verifying_key = signing_key.verifying_key();
+        let full_node_url = self
+            .full_node_url
+            .take()
+            .ok_or(MojaveClientError::MissingFullNodeUrls)?;
 
-        let params = SignedBlock {
-            block: block.clone(),
-            signature,
-            verifying_key,
-        };
+        let prover_url = self
+            .prover_url
+            .take()
+            .ok_or(MojaveClientError::MissingProverUrl)?;
 
-        let request = RpcRequest {
-            id: RpcRequestId::Number(1),
-            jsonrpc: "2.0".to_string(),
-            method: "mojave_sendBroadcastBlock".to_string(),
-            params: Some(vec![json!(params)]),
-        };
-        self.client
-            .send_request_race(
-                request,
-                self.full_node_urls
-                    .as_ref()
-                    .ok_or(MojaveClientError::MissingFullNodeUrls)?,
-            )
-            .await
-    }
+        let private_key = self
+            .private_key
+            .take()
+            .ok_or(MojaveClientError::MissingPrivateKey)?;
 
-    pub async fn send_proof_input(
-        &self,
-        proof_input: &ProverData,
-        sequencer_address: &str,
-    ) -> Result<JobId, MojaveClientError> {
-        let request = RpcRequest {
-            id: RpcRequestId::Number(1),
-            jsonrpc: "2.0".to_string(),
-            method: "mojave_sendProofInput".to_string(),
-            params: Some(vec![json!(proof_input), json!(sequencer_address)]),
-        };
-        self.client
-            .send_request_to_url(
-                &request,
-                self.prover_url
-                    .as_ref()
-                    .ok_or(MojaveClientError::MissingProverUrl)?,
-            )
-            .await
-    }
-
-    pub async fn get_job_id(&self) -> Result<Vec<JobId>, MojaveClientError> {
-        let request = RpcRequest {
-            id: RpcRequestId::Number(1),
-            jsonrpc: "2.0".to_string(),
-            method: "mojave_getJobId".to_string(),
-            params: None,
-        };
-        self.client
-            .send_request_to_url(
-                &request,
-                self.prover_url
-                    .as_ref()
-                    .ok_or(MojaveClientError::MissingProverUrl)?,
-            )
-            .await
-    }
-
-    pub async fn get_proof(&self, job_id: JobId) -> Result<ProofResponse, MojaveClientError> {
-        let request = RpcRequest {
-            id: RpcRequestId::Number(1),
-            jsonrpc: "2.0".to_string(),
-            method: "mojave_getProof".to_string(),
-            params: Some(vec![json!(job_id)]),
-        };
-        self.client
-            .send_request_to_url_with_retry(
-                &request,
-                self.prover_url
-                    .as_ref()
-                    .ok_or(MojaveClientError::MissingProverUrl)?,
-                self.max_attempts
-                    .ok_or(MojaveClientError::MissingMaxAttempts)?,
-                self.timeout.ok_or(MojaveClientError::MissingTimeout)?,
-            )
-            .await
-    }
-
-    pub async fn send_proof_response(
-        &self,
-        proof_response: &ProofResponse,
-    ) -> Result<(), MojaveClientError> {
-        let signing_key = self
-            .client
-            .inner
-            .signing_key
-            .as_ref()
-            .ok_or(MojaveClientError::MissingSigningKey)?;
-        let signature: Signature = signing_key.sign(proof_response)?;
-        let verifying_key = signing_key.verifying_key();
-
-        let params = SignedProofResponse {
-            proof_response: proof_response.clone(),
-            signature,
-            verifying_key,
-        };
-
-        let request = RpcRequest {
-            id: RpcRequestId::Number(1),
-            jsonrpc: "2.0".to_string(),
-            method: "mojave_sendProofResponse".to_string(),
-            params: Some(vec![json!(params)]),
-        };
-        self.client
-            .send_request_to_url(
-                &request,
-                self.sequencer_url
-                    .as_ref()
-                    .ok_or(MojaveClientError::MissingSequencerUrl)?,
-            )
-            .await
+        MojaveClient::new(
+            &sequencer_url,
+            &full_node_url,
+            &prover_url,
+            private_key,
+            self.timeout.unwrap_or(Duration::from_secs(0)),
+        )
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct MojaveClient {
     inner: Arc<MojaveClientInner>,
 }
 
-#[derive(Debug)]
 struct MojaveClientInner {
     client: reqwest::Client,
-    signing_key: Option<SigningKey>,
+    sequencer_url: Vec<Url>,
+    full_node_url: Vec<Url>,
+    prover_url: Vec<Url>,
+    private_key: SigningKey,
 }
 
 impl MojaveClient {
@@ -223,31 +107,94 @@ impl MojaveClient {
         MojaveClientBuilder::default()
     }
 
-    pub fn request_builder(&self) -> RequestBuilder {
-        RequestBuilder {
-            client: self.clone(),
-            full_node_urls: None,
-            prover_url: None,
-            sequencer_url: None,
-            timeout: None,
-            max_attempts: None,
+    pub fn new(
+        sequencer_url: &[String],
+        full_node_url: &[String],
+        prover_url: &[String],
+        private_key: SigningKey,
+        timeout: Duration,
+    ) -> Result<Self, MojaveClientError> {
+        // There will be default urls in the future, but for now, we require them.
+        let client = MojaveClient {
+            inner: Arc::new(MojaveClientInner {
+                client: ClientBuilder::default().timeout(timeout).build()?,
+                sequencer_url: sequencer_url
+                    .iter()
+                    .map(|url| Url::parse(url))
+                    .collect::<Result<Vec<Url>, _>>()
+                    .map_err(|error| MojaveClientError::Custom(error.to_string()))?,
+                full_node_url: full_node_url
+                    .iter()
+                    .map(|url| Url::parse(url))
+                    .collect::<Result<Vec<Url>, _>>()
+                    .map_err(|error| MojaveClientError::Custom(error.to_string()))?,
+                prover_url: prover_url
+                    .iter()
+                    .map(|url| Url::parse(url))
+                    .collect::<Result<Vec<Url>, _>>()
+                    .map_err(|error| MojaveClientError::Custom(error.to_string()))?,
+                private_key,
+            }),
+        };
+        Ok(client)
+    }
+
+    pub fn request(&self) -> Request<'_> {
+        Request {
+            client: &self,
+            urls: None,
+            max_retry: 0,
+            strategy: Strategy::Sequential,
         }
     }
 
-    /// Sends multiple RPC requests to a list of urls and returns
-    /// the first response without waiting for others to finish.
+    async fn send_request<T>(
+        &self,
+        request: &RpcRequest,
+        urls: &[Url],
+        max_retry: usize,
+        strategy: Strategy,
+    ) -> Result<T, MojaveClientError>
+    where
+        T: DeserializeOwned,
+    {
+        match strategy {
+            Strategy::Sequential => self.send_request_sequential(request, urls, max_retry).await,
+            Strategy::Race => self.send_request_race(request, urls).await,
+        }
+    }
+
+    async fn send_request_sequential<T>(
+        &self,
+        request: &RpcRequest,
+        urls: &[Url],
+        max_retry: usize,
+    ) -> Result<T, MojaveClientError>
+    where
+        T: DeserializeOwned,
+    {
+        let mut response = Err(MojaveClientError::Custom("All rpc calls failed".to_owned()));
+
+        for url in urls.iter() {
+            match self
+                .send_request_to_url_with_retry(request, url, max_retry)
+                .await
+            {
+                Ok(response) => return Ok(response),
+                Err(error) => response = Err(error),
+            }
+        }
+        response
+    }
+
     async fn send_request_race<T>(
         &self,
-        request: RpcRequest,
+        request: &RpcRequest,
         urls: &[Url],
     ) -> Result<T, MojaveClientError>
     where
         T: DeserializeOwned,
     {
-        if urls.is_empty() {
-            return Err(MojaveClientError::NoRPCUrlsConfigured);
-        }
-
         let requests: Vec<Pin<Box<Fuse<_>>>> = urls
             .iter()
             .map(|url| Box::pin(self.send_request_to_url(&request, url).fuse()))
@@ -257,34 +204,6 @@ impl MojaveClient {
             .await
             .map_err(|error| MojaveClientError::Custom(format!("All RPC calls failed: {error}")))?;
         Ok(response)
-    }
-
-    /// Sends the given RPC request to all configured URLs sequentially.
-    /// Returns the response from the first successful request, or the last error if all requests fail.
-    #[allow(unused)]
-    async fn send_request<T>(
-        &self,
-        request: &RpcRequest,
-        urls: &[Url],
-    ) -> Result<T, MojaveClientError>
-    where
-        T: DeserializeOwned,
-    {
-        if urls.is_empty() {
-            return Err(MojaveClientError::NoRPCUrlsConfigured);
-        }
-
-        let mut response = Err(MojaveClientError::Custom(
-            "All rpc calls failed".to_string(),
-        ));
-
-        for url in urls.iter() {
-            match self.send_request_to_url(request, url).await {
-                Ok(resp) => return Ok(resp),
-                Err(e) => response = Err(e),
-            }
-        }
-        response
     }
 
     async fn send_request_to_url<T>(
@@ -316,71 +235,167 @@ impl MojaveClient {
         }
     }
 
-    fn is_retryable(error: &MojaveClientError) -> bool {
-        match error {
-            MojaveClientError::RpcError(e) => {
-                let error_msg = e.to_string();
-                match error_msg.as_str() {
-                    msg if msg.starts_with("Internal Error") => true,
-                    msg if msg.starts_with("Unknown payload") => true,
-                    _ => false,
-                }
-            }
-            MojaveClientError::TimeOut => true,
-            _ => false,
-        }
-    }
-
     pub async fn send_request_to_url_with_retry<T>(
         &self,
         request: &RpcRequest,
         url: &Url,
-        max_attempts: u64,
-        request_timeout: u64,
+        max_retry: usize,
     ) -> Result<T, MojaveClientError>
     where
         T: DeserializeOwned,
     {
-        if max_attempts < 1 {
-            return Err(MojaveClientError::InvalidMaxAttempts(max_attempts));
-        }
+        let mut error_response = MojaveClientError::Custom("All retry failed".to_owned());
 
-        let mut attempts = 0;
-        let mut delay = INITIAL_RETRY_DELAY;
-        let mut last_error = None;
-        while attempts < max_attempts {
-            attempts += 1;
-            match timeout(
-                Duration::from_secs(request_timeout),
-                self.send_request_to_url(request, url),
-            )
+        for _ in 0..max_retry {
+            // TODO: Sleep in between request, but this can be implemented with caution
+            // because it can be a huge bottleneck especially when it comes to sequential requests.
+            match self.send_request_to_url::<T>(request, url).await {
+                Ok(response) => return Ok(response),
+                Err(error) => error_response = error,
+            }
+        }
+        Err(error_response)
+    }
+}
+
+pub struct Request<'a> {
+    client: &'a MojaveClient,
+    urls: Option<&'a [Url]>,
+    max_retry: usize,
+    strategy: Strategy,
+}
+
+impl<'a> Request<'a> {
+    pub fn urls(mut self, urls: &'a [Url]) -> Self {
+        self.urls = Some(urls);
+        self
+    }
+
+    pub fn max_retry(mut self, value: usize) -> Self {
+        self.max_retry = value;
+        self
+    }
+
+    pub fn strategy(mut self, strategy: Strategy) -> Self {
+        self.strategy = strategy;
+        self
+    }
+
+    pub async fn send_broadcast_block(&self, block: &Block) -> Result<(), MojaveClientError> {
+        let hash = block.hash();
+        let signing_key = &self.client.inner.private_key;
+        let signature: Signature = signing_key.sign(&hash)?;
+        let verifying_key = signing_key.verifying_key();
+
+        let params = SignedBlock {
+            block: block.clone(),
+            signature,
+            verifying_key,
+        };
+
+        let request = RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "mojave_sendBroadcastBlock".to_string(),
+            params: Some(vec![json!(params)]),
+        };
+
+        let urls = match self.urls {
+            Some(urls) => urls,
+            None => &self.client.inner.full_node_url,
+        };
+
+        self.client
+            .send_request(&request, urls, self.max_retry, self.strategy)
             .await
-            {
-                Ok(Ok(response)) => return Ok(response),
-                Ok(Err(e)) => {
-                    tracing::error!("Request failed (attempt {}): {}", attempts, e);
-                    last_error = Some(e);
-                    if Self::is_retryable(last_error.as_ref().unwrap()) {
-                        tracing::info!("Retrying request (attempt {})", attempts);
-                    } else {
-                        return Err(last_error.unwrap());
-                    }
-                }
-                Err(_) => {
-                    tracing::error!("Request timed out (attempt {})", attempts);
-                    last_error = Some(MojaveClientError::TimeOut);
-                }
-            }
+    }
 
-            // avoid sleeping on the last attempt
-            if attempts < max_attempts {
-                tokio::time::sleep(delay).await;
-                delay = delay.saturating_mul(BACKOFF_FACTOR);
-                if delay > MAX_DELAY {
-                    delay = MAX_DELAY;
-                }
-            }
-        }
-        Err(last_error.unwrap_or(MojaveClientError::RetryFailed(max_attempts)))
+    pub async fn send_proof_input(
+        &self,
+        proof_input: &ProverData,
+        sequencer_address: &str,
+    ) -> Result<JobId, MojaveClientError> {
+        let request = RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "mojave_sendProofInput".to_string(),
+            params: Some(vec![json!(proof_input), json!(sequencer_address)]),
+        };
+
+        let urls = match self.urls {
+            Some(urls) => urls,
+            None => &self.client.inner.prover_url,
+        };
+
+        self.client
+            .send_request(&request, urls, self.max_retry, self.strategy)
+            .await
+    }
+
+    pub async fn get_job_id(&self) -> Result<Vec<JobId>, MojaveClientError> {
+        let request = RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "mojave_getJobId".to_string(),
+            params: None,
+        };
+
+        let urls = match self.urls {
+            Some(urls) => urls,
+            None => &self.client.inner.prover_url,
+        };
+
+        self.client
+            .send_request(&request, urls, self.max_retry, self.strategy)
+            .await
+    }
+
+    pub async fn get_proof(&self, job_id: JobId) -> Result<ProofResponse, MojaveClientError> {
+        let request = RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "mojave_getProof".to_string(),
+            params: Some(vec![json!(job_id)]),
+        };
+
+        let urls = match self.urls {
+            Some(urls) => urls,
+            None => &self.client.inner.prover_url,
+        };
+
+        self.client
+            .send_request(&request, urls, self.max_retry, self.strategy)
+            .await
+    }
+
+    pub async fn send_proof_response(
+        &self,
+        proof_response: &ProofResponse,
+    ) -> Result<(), MojaveClientError> {
+        let signing_key = &self.client.inner.private_key;
+        let signature: Signature = signing_key.sign(proof_response)?;
+        let verifying_key = signing_key.verifying_key();
+
+        let params = SignedProofResponse {
+            proof_response: proof_response.clone(),
+            signature,
+            verifying_key,
+        };
+
+        let request = RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "mojave_sendProofResponse".to_string(),
+            params: Some(vec![json!(params)]),
+        };
+
+        let urls = match self.urls {
+            Some(urls) => urls,
+            None => &self.client.inner.sequencer_url,
+        };
+
+        self.client
+            .send_request(&request, urls, self.max_retry, self.strategy)
+            .await
     }
 }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -28,9 +28,10 @@ pub struct MojaveClientBuilder {
 }
 
 impl MojaveClientBuilder {
-    pub fn private_key(mut self, private_key: &str) -> Self {
-        self.signing_key = SigningKey::from_str(private_key).ok();
-        self
+    pub fn private_key(mut self, private_key: &str) -> Result<Self, MojaveClientError> {
+        let signing_key = SigningKey::from_str(private_key)?;
+        self.signing_key = Some(signing_key);
+        Ok(self)
     }
 
     pub fn build(self) -> Result<MojaveClient, MojaveClientError> {

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -28,6 +28,6 @@ pub enum MojaveClientError {
     MissingMaxAttempts,
     #[error("Missing timeout")]
     MissingTimeout,
-    #[error("Missing signing key")]
-    MissingSigningKey,
+    #[error("Missing private key")]
+    MissingPrivateKey,
 }

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -18,4 +18,16 @@ pub enum MojaveClientError {
     RetryFailed(u64),
     #[error("Invalid max attempts: {0}")]
     InvalidMaxAttempts(u64),
+    #[error("Missing full node URLs")]
+    MissingFullNodeUrls,
+    #[error("Missing prover URL")]
+    MissingProverUrl,
+    #[error("Missing sequencer URL")]
+    MissingSequencerUrl,
+    #[error("Missing max attempts")]
+    MissingMaxAttempts,
+    #[error("Missing timeout")]
+    MissingTimeout,
+    #[error("Missing signing key")]
+    MissingSigningKey,
 }

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -16,8 +16,8 @@ pub enum MojaveClientError {
     TimeOut,
     #[error("Retry failed after {0} attempts")]
     RetryFailed(u64),
-    #[error("Invalid max attempts: {0}")]
-    InvalidMaxAttempts(u64),
+    #[error("Invalid max retries: {0}")]
+    InvalidMaxRetries(u64),
     #[error("Missing full node URLs")]
     MissingFullNodeUrls,
     #[error("Missing prover URL")]

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -16,8 +16,6 @@ pub enum MojaveClientError {
     TimeOut,
     #[error("Retry failed after {0} attempts")]
     RetryFailed(u64),
-    #[error("Invalid max retries: {0}")]
-    InvalidMaxRetries(u64),
     #[error("Missing full node URLs")]
     MissingFullNodeUrls,
     #[error("Missing prover URL")]

--- a/crates/client/src/types.rs
+++ b/crates/client/src/types.rs
@@ -40,3 +40,15 @@ pub enum ProofResult {
     Proof(BatchProof),
     Error(String),
 }
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum RequestStrategy {
+    Sequential,
+    Race,
+}
+
+impl Default for RequestStrategy {
+    fn default() -> Self {
+        Self::Sequential
+    }
+}

--- a/crates/client/src/types.rs
+++ b/crates/client/src/types.rs
@@ -4,6 +4,14 @@ use mojave_signature::{Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use zkvm_interface::io::ProgramInput;
 
+#[derive(Clone, Copy, Debug)]
+pub enum Strategy {
+    /// Create sequential RPC requests that returns a first succesful response or an error if all requests fail.
+    Sequential,
+    /// Sends multiple RPC requests to a list of urls and returns the first response without waiting for others to finish.
+    Race,
+}
+
 // need to check whether we will use Message and contain other data or not
 #[derive(Serialize, Deserialize)]
 pub struct SignedBlock {

--- a/crates/client/src/types.rs
+++ b/crates/client/src/types.rs
@@ -40,15 +40,3 @@ pub enum ProofResult {
     Proof(BatchProof),
     Error(String),
 }
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum RequestStrategy {
-    Sequential,
-    Race,
-}
-
-impl Default for RequestStrategy {
-    fn default() -> Self {
-        Self::Sequential
-    }
-}

--- a/crates/proof-coordinator/src/errors.rs
+++ b/crates/proof-coordinator/src/errors.rs
@@ -37,4 +37,6 @@ pub enum ProofCoordinatorError {
     MissingBlob(u64),
     #[error("Proof failed for batch {0}: {1}")]
     ProofFailed(u64, String),
+    #[error("Failed to build the client: {0}")]
+    ClientError(#[from] mojave_client::MojaveClientError),
 }

--- a/crates/proof-coordinator/src/lib.rs
+++ b/crates/proof-coordinator/src/lib.rs
@@ -15,9 +15,9 @@ use zkvm_interface::io::ProgramInput;
 mod errors;
 
 pub struct ProofCoordinator {
+    client: MojaveClient,
     /// Come from the block builder
     proof_data_receiver: Receiver<u64>,
-    client: MojaveClient,
     sequencer_address: String,
 }
 
@@ -28,12 +28,14 @@ impl ProofCoordinator {
         sequencer_address: String,
     ) -> Result<Self, ProofCoordinatorError> {
         let prover_url = vec![prover_address.to_string()];
+        let client = MojaveClient::builder()
+            .prover_url(&prover_url)
+            .build()
+            .map_err(ProofCoordinatorError::ClientError)?;
+
         Ok(Self {
+            client,
             proof_data_receiver,
-            client: MojaveClient::builder()
-                .prover_url(&prover_url)
-                .build()
-                .map_err(ProofCoordinatorError::ClientError)?,
             sequencer_address: sequencer_address.to_string(),
         })
     }

--- a/crates/proof-coordinator/src/lib.rs
+++ b/crates/proof-coordinator/src/lib.rs
@@ -35,7 +35,7 @@ impl ProofCoordinator {
             client: MojaveClient::builder()
                 .private_key(private_key)
                 .build()
-                .map_err(|e| ProofCoordinatorError::ClientError(e))?,
+                .map_err(ProofCoordinatorError::ClientError)?,
             prover_url: Url::parse(prover_address).unwrap(),
             sequencer_address: sequencer_address.to_string(),
         })

--- a/crates/proof-coordinator/src/lib.rs
+++ b/crates/proof-coordinator/src/lib.rs
@@ -29,7 +29,7 @@ impl ProofCoordinator {
     ) -> Result<Self, ProofCoordinatorError> {
         let prover_url = vec![prover_address.to_string()];
         let client = MojaveClient::builder()
-            .prover_url(&prover_url)
+            .prover_urls(&prover_url)
             .build()
             .map_err(ProofCoordinatorError::ClientError)?;
 

--- a/crates/proof-coordinator/src/lib.rs
+++ b/crates/proof-coordinator/src/lib.rs
@@ -20,14 +20,14 @@ pub struct ProofCoordinator {
     proof_data_receiver: Receiver<u64>,
     client: MojaveClient,
     prover_url: Url,
-    sequencer_url: Url,
+    sequencer_address: String,
 }
 
 impl ProofCoordinator {
     pub fn new(
         proof_data_receiver: Receiver<u64>,
         prover_address: &str,
-        sequencer_address: &str,
+        sequencer_address: String,
         private_key: &str,
     ) -> Result<Self, ProofCoordinatorError> {
         Ok(Self {
@@ -35,9 +35,9 @@ impl ProofCoordinator {
             client: MojaveClient::builder()
                 .private_key(private_key)
                 .build()
-                .map_err(|e| ProofCoordinatorError::Custom(e.to_string()))?, // TODO: Handle error
+                .map_err(|e| ProofCoordinatorError::ClientError(e))?,
             prover_url: Url::parse(prover_address).unwrap(),
-            sequencer_url: Url::parse(sequencer_address).unwrap(),
+            sequencer_address: sequencer_address.to_string(),
         })
     }
 
@@ -60,8 +60,7 @@ impl ProofCoordinator {
             .client
             .request_builder()
             .prover_url(&self.prover_url)
-            .sequencer_url(&self.sequencer_url)
-            .send_proof_input(&input)
+            .send_proof_input(&input, &self.sequencer_address)
             .await
             .map_err(|e| ProofCoordinatorError::Custom(e.to_string()))?;
 

--- a/crates/proof-coordinator/src/lib.rs
+++ b/crates/proof-coordinator/src/lib.rs
@@ -28,15 +28,14 @@ impl ProofCoordinator {
         proof_data_receiver: Receiver<u64>,
         prover_address: &str,
         sequencer_address: String,
-        private_key: &str,
     ) -> Result<Self, ProofCoordinatorError> {
         Ok(Self {
             proof_data_receiver,
             client: MojaveClient::builder()
-                .private_key(private_key)
                 .build()
                 .map_err(ProofCoordinatorError::ClientError)?,
-            prover_url: Url::parse(prover_address).unwrap(),
+            prover_url: Url::parse(prover_address)
+                .map_err(|e| ProofCoordinatorError::Custom(e.to_string()))?,
             sequencer_address: sequencer_address.to_string(),
         })
     }

--- a/crates/proof-coordinator/src/lib.rs
+++ b/crates/proof-coordinator/src/lib.rs
@@ -18,8 +18,9 @@ mod errors;
 pub struct ProofCoordinator {
     /// Come from the block builder
     proof_data_receiver: Receiver<u64>,
-    /// Mojave client
     client: MojaveClient,
+    prover_url: Url,
+    sequencer_url: Url,
 }
 
 impl ProofCoordinator {
@@ -33,10 +34,10 @@ impl ProofCoordinator {
             proof_data_receiver,
             client: MojaveClient::builder()
                 .private_key(private_key)
-                .prover_url(Url::parse(prover_address).unwrap())
-                .sequencer_url(Url::parse(sequencer_address).unwrap())
                 .build()
                 .map_err(|e| ProofCoordinatorError::Custom(e.to_string()))?, // TODO: Handle error
+            prover_url: Url::parse(prover_address).unwrap(),
+            sequencer_url: Url::parse(sequencer_address).unwrap(),
         })
     }
 
@@ -57,6 +58,9 @@ impl ProofCoordinator {
         // send proof input to the prover
         let _job_id = self
             .client
+            .request_builder()
+            .prover_url(&self.prover_url)
+            .sequencer_url(&self.sequencer_url)
             .send_proof_input(&input)
             .await
             .map_err(|e| ProofCoordinatorError::Custom(e.to_string()))?;

--- a/crates/proof-coordinator/src/lib.rs
+++ b/crates/proof-coordinator/src/lib.rs
@@ -7,7 +7,7 @@ use ethrex_storage::Store;
 use ethrex_storage_rollup::StoreRollup;
 use mojave_client::{
     MojaveClient,
-    types::{ProofResponse, ProofResult, ProverData},
+    types::{ProofResponse, ProofResult, ProverData, Strategy},
 };
 use tokio::sync::mpsc::Receiver;
 use zkvm_interface::io::ProgramInput;
@@ -56,6 +56,7 @@ impl ProofCoordinator {
         let _job_id = self
             .client
             .request()
+            .strategy(Strategy::Sequential)
             .send_proof_input(&input, &self.sequencer_address)
             .await
             .map_err(|e| ProofCoordinatorError::Custom(e.to_string()))?;

--- a/crates/prover/src/rpc/mod.rs
+++ b/crates/prover/src/rpc/mod.rs
@@ -63,7 +63,9 @@ pub async fn start_api(
     let client = MojaveClient::builder()
         .private_key(private_key)
         .build()
-        .map_err(|err| RpcErr::Internal(format!("Error to start client to send proof back: {err}")))?;
+        .map_err(|err| {
+            RpcErr::Internal(format!("Error to start client to send proof back: {err}"))
+        })?;
     tracing::info!("MojaveClient initialized");
 
     // Start the proof worker in the background.
@@ -129,7 +131,9 @@ fn spawn_proof_worker(
                         .upsert_proof(&job_id, proof_response.clone())
                         .await;
                     match client
-                        .send_proof_response(&proof_response, &job.sequencer_url)
+                        .request_builder()
+                        .sequencer_url(&job.sequencer_url)
+                        .send_proof_response(&proof_response)
                         .await
                     {
                         Ok(_) => {

--- a/crates/prover/src/rpc/mod.rs
+++ b/crates/prover/src/rpc/mod.rs
@@ -61,8 +61,7 @@ pub async fn start_api(
     info!("Starting HTTP server at {http_addr}");
 
     let client = MojaveClient::builder()
-        .private_key(private_key)
-        .map_err(|err| RpcErr::Internal(err.to_string()))?
+        .private_key(private_key.to_string())
         .build()
         .map_err(|err| RpcErr::Internal(err.to_string()))?;
     tracing::info!("MojaveClient initialized");
@@ -130,8 +129,8 @@ fn spawn_proof_worker(
                         .upsert_proof(&job_id, proof_response.clone())
                         .await;
                     match client
-                        .request_builder()
-                        .sequencer_url(&job.sequencer_url)
+                        .request()
+                        .urls(std::slice::from_ref(&job.sequencer_url))
                         .send_proof_response(&proof_response)
                         .await
                     {

--- a/crates/prover/src/rpc/mod.rs
+++ b/crates/prover/src/rpc/mod.rs
@@ -63,9 +63,7 @@ pub async fn start_api(
     let client = MojaveClient::builder()
         .private_key(private_key)
         .build()
-        .map_err(|err| {
-            RpcErr::Internal(format!("Error to start client to send proof back: {err}"))
-        })?;
+        .map_err(|err| RpcErr::Internal(err.to_string()))?;
     tracing::info!("MojaveClient initialized");
 
     // Start the proof worker in the background.

--- a/crates/prover/src/rpc/mod.rs
+++ b/crates/prover/src/rpc/mod.rs
@@ -60,9 +60,10 @@ pub async fn start_api(
     let http_server = axum::serve(http_listener, http_router).into_future();
     info!("Starting HTTP server at {http_addr}");
 
-    let client = MojaveClient::new(private_key).map_err(|err| {
-        RpcErr::Internal(format!("Error to start client to send proof back: {err}"))
-    })?;
+    let client = MojaveClient::builder()
+        .private_key(private_key)
+        .build()
+        .map_err(|err| RpcErr::Internal(format!("Error to start client to send proof back: {err}")))?;
     tracing::info!("MojaveClient initialized");
 
     // Start the proof worker in the background.

--- a/crates/prover/src/rpc/mod.rs
+++ b/crates/prover/src/rpc/mod.rs
@@ -19,7 +19,7 @@ use ethrex_rpc::{
 
 use mojave_client::{
     MojaveClient,
-    types::{ProofResponse, ProofResult},
+    types::{ProofResponse, ProofResult, Strategy},
 };
 use mojave_utils::rpc::rpc_response;
 
@@ -131,6 +131,7 @@ fn spawn_proof_worker(
                     match client
                         .request()
                         .urls(std::slice::from_ref(&job.sequencer_url))
+                        .strategy(Strategy::Sequential)
                         .send_proof_response(&proof_response)
                         .await
                     {

--- a/crates/prover/src/rpc/mod.rs
+++ b/crates/prover/src/rpc/mod.rs
@@ -62,6 +62,7 @@ pub async fn start_api(
 
     let client = MojaveClient::builder()
         .private_key(private_key)
+        .map_err(|err| RpcErr::Internal(err.to_string()))?
         .build()
         .map_err(|err| RpcErr::Internal(err.to_string()))?;
     tracing::info!("MojaveClient initialized");

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -16,6 +16,7 @@ use mojave_utils::unique_heap::AsyncUniqueHeap;
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
+use reqwest::Url;
 
 pub const TEST_GENESIS: &str = include_str!("../../../tests/mock-genesis.json");
 pub const TEST_SEQUENCER_ADDR: &str = "127.0.0.1:8502";
@@ -110,7 +111,11 @@ pub async fn start_test_api_sequencer(
     let local_p2p_node = example_p2p_node();
     let rollup_store = example_rollup_store().await;
     let private_key = std::env::var("PRIVATE_KEY").unwrap();
-    let client = MojaveClient::new(&private_key).unwrap();
+    let client = MojaveClient::builder()
+        .private_key(&private_key)
+        .sequencer_url(Url::parse(TEST_SEQUENCER_ADDR).unwrap())
+        .build()
+        .unwrap();
     let rpc_api = start_api_block_producer(
         http_addr,
         authrpc_addr,

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -112,6 +112,7 @@ pub async fn start_test_api_sequencer(
     let private_key = std::env::var("PRIVATE_KEY").unwrap();
     let client = MojaveClient::builder()
         .private_key(&private_key)
+        .unwrap()
         .build()
         .unwrap();
     let rpc_api = start_api_block_producer(

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -16,7 +16,6 @@ use mojave_utils::unique_heap::AsyncUniqueHeap;
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
-use reqwest::Url;
 
 pub const TEST_GENESIS: &str = include_str!("../../../tests/mock-genesis.json");
 pub const TEST_SEQUENCER_ADDR: &str = "127.0.0.1:8502";
@@ -113,7 +112,6 @@ pub async fn start_test_api_sequencer(
     let private_key = std::env::var("PRIVATE_KEY").unwrap();
     let client = MojaveClient::builder()
         .private_key(&private_key)
-        .sequencer_url(Url::parse(TEST_SEQUENCER_ADDR).unwrap())
         .build()
         .unwrap();
     let rpc_api = start_api_block_producer(

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -111,8 +111,7 @@ pub async fn start_test_api_sequencer(
     let rollup_store = example_rollup_store().await;
     let private_key = std::env::var("PRIVATE_KEY").unwrap();
     let client = MojaveClient::builder()
-        .private_key(&private_key)
-        .unwrap()
+        .private_key(private_key)
         .build()
         .unwrap();
     let rpc_api = start_api_block_producer(

--- a/crates/tests/tests/integration.rs
+++ b/crates/tests/tests/integration.rs
@@ -116,6 +116,7 @@ mod tests {
         let private_key = std::env::var("PRIVATE_KEY").unwrap();
         let client = MojaveClient::builder()
             .private_key(&private_key)
+            .unwrap()
             .build()
             .unwrap();
         let result = client
@@ -201,6 +202,7 @@ mod tests {
         let private_key = std::env::var("PRIVATE_KEY").unwrap();
         let client = MojaveClient::builder()
             .private_key(&private_key)
+            .unwrap()
             .build()
             .unwrap();
         let result = client

--- a/crates/tests/tests/integration.rs
+++ b/crates/tests/tests/integration.rs
@@ -116,10 +116,11 @@ mod tests {
         let private_key = std::env::var("PRIVATE_KEY").unwrap();
         let client = MojaveClient::builder()
             .private_key(&private_key)
-            .sequencer_url(Url::parse(&server_url).unwrap())
             .build()
             .unwrap();
         let result = client
+            .request_builder()
+            .full_node_urls(&[Url::parse(&server_url).unwrap()])
             .send_broadcast_block(&test_block)
             .await;
 
@@ -200,10 +201,11 @@ mod tests {
         let private_key = std::env::var("PRIVATE_KEY").unwrap();
         let client = MojaveClient::builder()
             .private_key(&private_key)
-            .sequencer_url(Url::parse(&server_url).unwrap())
             .build()
             .unwrap();
         let result = client
+            .request_builder()
+            .full_node_urls(&[Url::parse(&server_url).unwrap()])
             .send_broadcast_block(&test_block)
             .await;
 
@@ -346,6 +348,8 @@ mod tests {
         };
 
         sequencer_client
+            .request_builder()
+            .full_node_urls(&[Url::parse(&format!("http://{sequencer_http_addr}")).unwrap()])
             .send_broadcast_block(&block)
             .await
             .unwrap();

--- a/crates/tests/tests/integration.rs
+++ b/crates/tests/tests/integration.rs
@@ -112,8 +112,6 @@ mod tests {
         // Wait for server to start
         sleep(Duration::from_millis(100)).await;
 
-        println!("[DEBUG] server_url: {:?}", server_url);
-
         // create mojave client and test block broadcast
         let private_key = std::env::var("PRIVATE_KEY").unwrap();
         let client = MojaveClient::builder()
@@ -128,8 +126,6 @@ mod tests {
             .await;
 
         server_handle.abort();
-
-        println!("[DEBUG] result: {:?}", result);
 
         // assert the response
         assert!(result.is_ok(), "Communication should complete");
@@ -187,7 +183,6 @@ mod tests {
         server_handle.abort();
 
         // assert the response
-        println!("[DEBUG] result: {:?}", result);
         assert!(result.is_ok(), "Communication should complete");
     }
 

--- a/crates/tests/tests/integration.rs
+++ b/crates/tests/tests/integration.rs
@@ -349,7 +349,7 @@ mod tests {
 
         sequencer_client
             .request_builder()
-            .full_node_urls(&[Url::parse(&format!("http://{sequencer_http_addr}")).unwrap()])
+            .full_node_urls(&[Url::parse(&format!("http://{full_node_http_addr}")).unwrap()])
             .send_broadcast_block(&block)
             .await
             .unwrap();

--- a/crates/tests/tests/integration.rs
+++ b/crates/tests/tests/integration.rs
@@ -114,9 +114,13 @@ mod tests {
 
         // create mojave client and test block broadcast
         let private_key = std::env::var("PRIVATE_KEY").unwrap();
-        let client = MojaveClient::new(&private_key).unwrap();
+        let client = MojaveClient::builder()
+            .private_key(&private_key)
+            .sequencer_url(Url::parse(&server_url).unwrap())
+            .build()
+            .unwrap();
         let result = client
-            .send_broadcast_block(&test_block, &[Url::parse(&server_url).unwrap()])
+            .send_broadcast_block(&test_block)
             .await;
 
         server_handle.abort();
@@ -194,9 +198,13 @@ mod tests {
 
         // create mojave client and test block broadcast
         let private_key = std::env::var("PRIVATE_KEY").unwrap();
-        let client = MojaveClient::new(&private_key).unwrap();
+        let client = MojaveClient::builder()
+            .private_key(&private_key)
+            .sequencer_url(Url::parse(&server_url).unwrap())
+            .build()
+            .unwrap();
         let result = client
-            .send_broadcast_block(&test_block, &[Url::parse(&server_url).unwrap()])
+            .send_broadcast_block(&test_block)
             .await;
 
         // assert the response
@@ -337,10 +345,8 @@ mod tests {
             },
         };
 
-        let full_node_urls = vec![Url::parse(&format!("http://{full_node_http_addr}")).unwrap()];
-
         sequencer_client
-            .send_broadcast_block(&block, &full_node_urls)
+            .send_broadcast_block(&block)
             .await
             .unwrap();
     }


### PR DESCRIPTION
- Introduces MojaveClientBuilder for client initialization 
- Adds RequestBuilder pattern for method-specific configurations like URLs and retry parameters
- Refactors all client method calls across the codebase to use the new builder patterns