### PR TITLE
Dev/kanet1105/110

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4751,6 +4751,7 @@ dependencies = [
  "futures",
  "hex",
  "mojave-client",
+ "mojave-node-lib",
  "mojave-signature",
  "mojave-utils",
  "reqwest 0.12.23",

--- a/cmd/sequencer/src/cli.rs
+++ b/cmd/sequencer/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{ArgAction, ArgGroup, Parser, Subcommand};
+use mojave_block_producer::types::BlockProducerOptions;
 use mojave_node_lib::types::{Node, SyncMode};
 use mojave_utils::network::Network;
 use tracing::Level;
@@ -283,5 +284,16 @@ impl std::fmt::Debug for SequencerOptions {
             .field("full_node_addresses", &self.full_node_addresses)
             .field("block_time", &self.block_time)
             .finish()
+    }
+}
+
+impl From<&SequencerOptions> for BlockProducerOptions {
+    fn from(value: &SequencerOptions) -> Self {
+        Self {
+            full_node_addresses: value.full_node_addresses.clone(),
+            prover_address: value.prover_address.clone(),
+            block_time: value.block_time,
+            private_key: value.private_key.clone(),
+        }
     }
 }

--- a/cmd/sequencer/src/main.rs
+++ b/cmd/sequencer/src/main.rs
@@ -1,11 +1,9 @@
 pub mod cli;
 
 use crate::cli::Command;
-use mojave_block_producer::{BlockProducer, BlockProducerContext};
-use mojave_client::MojaveClient;
+use mojave_block_producer::types::BlockProducerOptions;
 use mojave_node_lib::types::MojaveNode;
-use reqwest::Url;
-use std::{error::Error, time::Duration};
+use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -27,47 +25,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     tracing::error!("Failed to initialize the node: {}", error);
                     std::process::exit(1);
                 });
-
-            let mojave_client = MojaveClient::new(sequencer_options.private_key.as_str())?;
-            let context = BlockProducerContext::new(
-                node.store.clone(),
-                node.blockchain.clone(),
-                node.rollup_store.clone(),
-                node.genesis.coinbase,
-            );
-            let block_producer = BlockProducer::start(context, 100);
-            let full_node_urls: Vec<Url> = sequencer_options
-                .full_node_addresses
-                .iter()
-                .map(|address| {
-                    Url::parse(address)
-                        .unwrap_or_else(|error| panic!("Failed to parse URL: {error}"))
-                })
-                .collect();
-
-            tokio::spawn(async move {
-                loop {
-                    match block_producer.build_block().await {
-                        Ok(block) => mojave_client
-                            .send_broadcast_block(&block, &full_node_urls)
-                            .await
-                            .unwrap_or_else(|error| tracing::error!("{}", error)),
-                        Err(error) => {
-                            tracing::error!("Failed to build a block: {}", error);
-                        }
-                    }
-                    tokio::time::sleep(Duration::from_millis(sequencer_options.block_time)).await;
-                }
-            });
-
+            let block_producer_options: BlockProducerOptions = (&sequencer_options).into();
             tokio::select! {
-                res = node.run(&node_options) => {
+                res = mojave_block_producer::run(node, &node_options, &block_producer_options) => {
                     if let Err(err) = res {
-                        tracing::error!("Node stopped unexpectedly: {}", err);
+                        tracing::error!("Sequencer stopped unexpectedly: {}", err);
                     }
                 }
                 _ = tokio::signal::ctrl_c() => {
-                    tracing::info!("Shutting down the full node..");
+                    tracing::info!("Shutting down the sequencer..");
                 }
             }
         }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -11,6 +11,7 @@ documentation = { workspace = true }
 [dependencies]
 mojave-utils = { workspace = true }
 mojave-client = { workspace = true }
+mojave-node-lib = { workspace = true }
 mojave-signature = { workspace = true }
 
 ethrex-blockchain = { workspace = true }

--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -3,7 +3,8 @@ mod error;
 mod service;
 
 pub mod rpc;
+pub mod types;
 
 pub use context::BlockProducerContext;
 pub use error::BlockProducerError;
-pub use service::BlockProducer;
+pub use service::{BlockProducer, run};

--- a/crates/block-producer/src/types.rs
+++ b/crates/block-producer/src/types.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, Clone)]
+pub struct BlockProducerOptions {
+    pub full_node_addresses: Vec<String>,
+    pub prover_address: String,
+    pub block_time: u64,
+    pub private_key: String,
+}

--- a/justfile
+++ b/justfile
@@ -19,7 +19,8 @@ full: clean
 node:
     export $(cat .env | xargs) && \
     cargo run --release --bin mojave-node init \
-        --datadir {{current-dir}}/mojave-node
+        --datadir {{current-dir}}/mojave-node \
+        --network {{current-dir}}/data/testnet-genesis.json
 
 sequencer:
     export $(cat .env | xargs) && \
@@ -27,7 +28,8 @@ sequencer:
         --http.port 1739 \
         --full_node.addresses http://0.0.0.0:8545 \
         --datadir {{current-dir}}/mojave-sequencer \
-        --private_key 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        --private_key 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+        --network {{current-dir}}/data/testnet-genesis.json
 
 generate-key-pair:
 	cargo build --bin mojave


### PR DESCRIPTION
- moved the sequencer logic from binary to `BlockProducer::run()`.
- fixed invalid header error when the sequencer tries to create a block.