### PR TITLE
fix: handle rpc err

### DIFF
--- a/crates/block-producer/src/service.rs
+++ b/crates/block-producer/src/service.rs
@@ -44,7 +44,7 @@ pub async fn run(
 
     let local_node_record = node.local_node_record.lock().await.clone();
 
-    let api_task = tokio::spawn(start_api(
+    let api_task = start_api(
         get_http_socket_addr(&node_options.http_addr, &node_options.http_port),
         get_authrpc_socket_addr(&node_options.authrpc_addr, &node_options.authrpc_port),
         node.store,
@@ -56,7 +56,7 @@ pub async fn run(
         node.peer_handler,
         get_client_version(),
         node.rollup_store,
-    ));
+    );
     tokio::select! {
         res = api_task => {
             if let Err(err) = res {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -113,7 +113,7 @@ impl MojaveNode {
     pub async fn run(self, options: &NodeOptions) -> Result<(), Box<dyn std::error::Error>> {
         let rpc_shutdown = CancellationToken::new();
         let jwt_secret = read_jwtsecret_file(&options.authrpc_jwtsecret)?;
-        let api_task = tokio::spawn(start_api(
+        let api_task = start_api(
             get_http_socket_addr(&options.http_addr, &options.http_port),
             get_authrpc_socket_addr(&options.authrpc_addr, &options.authrpc_port),
             self.store,
@@ -127,7 +127,7 @@ impl MojaveNode {
             self.rollup_store.clone(),
             AsyncUniqueHeap::new(),
             rpc_shutdown.clone(),
-        ));
+        );
         tokio::select! {
             res = api_task => {
                 if let Err(err) = res {


### PR DESCRIPTION
remove tokio swawn cause it return `JoinErr` but we have to handle `RpcErr`