### PR TITLE
chore: put RpcRequestId as options to respect JSON-RPC 2.0 RFC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
  "jobserver",

--- a/crates/rpc/core/src/lib.rs
+++ b/crates/rpc/core/src/lib.rs
@@ -1,9 +1,8 @@
 pub mod types;
 pub mod utils;
 
-pub use ethrex_rpc::utils::{
-    RpcErr, RpcErrorResponse, RpcRequest, RpcRequestId, RpcSuccessResponse,
-};
+pub use crate::types::RpcErrorResponse;
+pub use ethrex_rpc::utils::{RpcErr, RpcRequest, RpcRequestId, RpcSuccessResponse};
 
 pub mod prelude {
     pub use crate::{types::*, utils::*};

--- a/crates/rpc/core/src/types.rs
+++ b/crates/rpc/core/src/types.rs
@@ -1,4 +1,7 @@
+use ethrex_rpc::RpcErrorMetadata;
 use serde::{Deserialize, Serialize};
+
+use crate::RpcRequestId;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Namespace {
@@ -24,4 +27,11 @@ pub enum MojaveRequestMethods {
     GetProof,
     #[serde(rename = "moj_sendProofInput")]
     SendProofInput,
+}
+
+#[derive(Serialize)]
+pub struct RpcErrorResponse {
+    pub jsonrpc: String,
+    pub id: Option<RpcRequestId>,
+    pub error: RpcErrorMetadata,
 }

--- a/crates/rpc/core/src/utils.rs
+++ b/crates/rpc/core/src/utils.rs
@@ -1,21 +1,30 @@
 use crate::{
-    RpcErr, RpcErrorResponse, RpcRequest, RpcRequestId, RpcSuccessResponse, types::Namespace,
+    RpcErr, RpcRequest, RpcRequestId, RpcSuccessResponse,
+    types::{Namespace, RpcErrorResponse},
 };
 use serde_json::Value;
 
-pub fn rpc_response(id: RpcRequestId, res: Result<Value, RpcErr>) -> Result<Value, RpcErr> {
-    Ok(match res {
-        Ok(result) => serde_json::to_value(RpcSuccessResponse {
-            id,
-            jsonrpc: "2.0".to_string(),
-            result,
-        }),
-        Err(error) => serde_json::to_value(RpcErrorResponse {
-            id,
-            jsonrpc: "2.0".to_string(),
-            error: error.into(),
-        }),
-    }?)
+pub fn rpc_response(id: RpcRequestId, result: Result<Value, RpcErr>) -> Result<Value, RpcErr> {
+    match result {
+        Ok(value) => rpc_response_success(id, value),
+        Err(e) => rpc_response_error(Some(id), e),
+    }
+}
+
+pub fn rpc_response_success(id: RpcRequestId, result: Value) -> Result<Value, RpcErr> {
+    Ok(serde_json::to_value(RpcSuccessResponse {
+        id,
+        jsonrpc: "2.0".to_string(),
+        result,
+    })?)
+}
+
+pub fn rpc_response_error(id: Option<RpcRequestId>, error: RpcErr) -> Result<Value, RpcErr> {
+    Ok(serde_json::to_value(RpcErrorResponse {
+        jsonrpc: "2.0".to_string(),
+        id,
+        error: error.into(),
+    })?)
 }
 
 pub fn resolve_namespace(req: &RpcRequest) -> Result<Namespace, RpcErr> {
@@ -32,5 +41,42 @@ pub fn resolve_namespace(req: &RpcRequest) -> Result<Namespace, RpcErr> {
         "txpool" => Ok(Namespace::TxPool),
         "web3" => Ok(Namespace::Web3),
         _others => Err(RpcErr::MethodNotFound(req.method.clone())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn success_requires_id_and_echoes_it() {
+        let out = rpc_response_success(RpcRequestId::Number(42), json!("ok")).unwrap();
+        assert!(out.is_object());
+        let obj = out.as_object().unwrap();
+        assert_eq!(obj.get("jsonrpc").and_then(|v| v.as_str()), Some("2.0"));
+        assert_eq!(obj.get("id").and_then(|v| v.as_i64()), Some(42));
+        assert_eq!(obj.get("result"), Some(&json!("ok")));
+    }
+
+    #[test]
+    fn error_with_id_keeps_id() {
+        let out = rpc_response_error(Some(RpcRequestId::Number(7)), RpcErr::BadParams("x".into()))
+            .unwrap();
+        let obj = out.as_object().expect("object response");
+        assert_eq!(obj.get("jsonrpc").and_then(|v| v.as_str()), Some("2.0"));
+        assert_eq!(obj.get("id").and_then(|v| v.as_i64()), Some(7));
+        assert!(obj.get("error").is_some());
+        assert!(obj.get("result").is_none());
+    }
+
+    #[test]
+    fn error_without_id_sets_null_id() {
+        let out = rpc_response_error(None, RpcErr::BadParams("y".into())).unwrap();
+        let obj = out.as_object().expect("object response");
+        assert_eq!(obj.get("jsonrpc").and_then(|v| v.as_str()), Some("2.0"));
+        assert!(obj.get("id").unwrap().is_null());
+        assert!(obj.get("error").is_some());
+        assert!(obj.get("result").is_none());
     }
 }

--- a/crates/rpc/server/src/lib.rs
+++ b/crates/rpc/server/src/lib.rs
@@ -6,7 +6,7 @@ use ethrex_rpc::RpcRequestWrapper;
 use mojave_rpc_core::{
     RpcErr, RpcRequest,
     types::Namespace,
-    utils::{resolve_namespace, rpc_response},
+    utils::{resolve_namespace, rpc_response, rpc_response_error},
 };
 use serde_json::Value;
 use tower_http::cors::CorsLayer;
@@ -170,11 +170,9 @@ async fn handle<C: Clone + Send + Sync + 'static>(
     let wrapper = match serde_json::from_str::<RpcRequestWrapper>(&body) {
         Ok(wrapper) => wrapper,
         Err(_) => {
-            let error_response = rpc_response(
-                mojave_rpc_core::RpcRequestId::Number(0),
-                Err(RpcErr::BadParams("Invalid JSON".to_string())),
-            )
-            .unwrap_or_else(|_| serde_json::json!({"error": "Parse error"}));
+            let error_response =
+                rpc_response_error(None, RpcErr::BadParams("Invalid JSON".to_string()))
+                    .unwrap_or_else(|_| serde_json::json!({"error": "Parse error"}));
             return Err((StatusCode::BAD_REQUEST, Json(error_response)));
         }
     };


### PR DESCRIPTION
This PR aim to respect the JSON-RPC 2.0 RFC, in the rfc it's state that if you can't interpret the ID you have to return null 

closes #162
