### PR TITLE
feat: handle shutdown properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4301,6 +4301,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
 ]
 

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -30,4 +30,5 @@ axum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/crates/node/src/rpc/api.rs
+++ b/crates/node/src/rpc/api.rs
@@ -76,7 +76,7 @@ pub async fn start_api(
         .await
         .map_err(|error| RpcErr::Internal(error.to_string()))?;
     let http_server = axum::serve(http_listener, http_router)
-        .with_graceful_shutdown(ethrex_rpc::shutdown_signal())
+        .with_graceful_shutdown(shutdown_token.cancelled_owned())
         .into_future();
     info!("Starting HTTP server at {http_addr}");
 

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -115,6 +115,7 @@ pub async fn start_test_api_sequencer(
         .private_key(private_key)
         .build()
         .unwrap();
+    let cancel_token = CancellationToken::new();
     let rpc_api = start_api_block_producer(
         http_addr,
         authrpc_addr,
@@ -127,6 +128,7 @@ pub async fn start_test_api_sequencer(
         PeerHandler::dummy(),
         "ethrex/test".to_string(),
         rollup_store,
+        cancel_token,
     );
 
     let (sequencer_tx, sequencer_rx) = tokio::sync::oneshot::channel();


### PR DESCRIPTION
- We should handle SIGINT for each service (node, sequencer, ...) instead of handling it all in one place
- Remove the handle SIGINT (ctrl_c) inside daemon