### PR TITLE
fix: task APIs

### DIFF
--- a/crates/task/src/error.rs
+++ b/crates/task/src/error.rs
@@ -4,6 +4,6 @@ pub enum Error {
     Send(String),
     #[error("Failed to receive a response: {0}")]
     Receive(#[from] tokio::sync::oneshot::error::RecvError),
-    #[error("Task handle for {0} dropped..")]
-    TaskHandleDropped(&'static str),
+    #[error("Task error: {0}")]
+    Task(Box<dyn std::error::Error>),
 }

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -8,3 +8,65 @@ pub use constants::*;
 pub use error::Error;
 pub use handle::TaskHandle;
 pub use traits::Task;
+
+#[tokio::test]
+async fn works() {
+    let handle = BlockProducer::new().spawn();
+    for i in 0..5 {
+        let response = handle.request(Request::BuildBlock).await.unwrap();
+        if let Response::Block(value) = response {
+            assert!(value == i);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+    }
+    handle.shutdown().await.unwrap();
+
+    pub struct BlockProducer {
+        block_number: std::sync::atomic::AtomicUsize,
+    }
+
+    impl Task for BlockProducer {
+        type Request = Request;
+        type Response = Response;
+        type Error = Error;
+
+        async fn handle_request(
+            &self,
+            request: Self::Request,
+        ) -> Result<Self::Response, Self::Error> {
+            match request {
+                Request::BuildBlock => Ok(Response::Block(
+                    self.block_number
+                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst),
+                )),
+            }
+        }
+
+        async fn on_shutdown(&self) -> Result<(), Self::Error> {
+            println!("Shutting down the block producer..");
+            Ok(())
+        }
+    }
+
+    impl BlockProducer {
+        pub fn new() -> Self {
+            Self {
+                block_number: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+
+    pub enum Request {
+        BuildBlock,
+    }
+
+    #[allow(unused)]
+    #[derive(Debug)]
+    pub enum Response {
+        Block(usize),
+        PlaceHolder,
+    }
+
+    #[derive(thiserror::Error, Debug)]
+    pub enum Error {}
+}


### PR DESCRIPTION
- Remove `Error::HandleDropped(&'static str)`.
- Change nested error pattern `Result<Result<T::Response, T::Error>, Error>` to `Result<T::Response, Error>` for ergonomics.
- Add `TaskHandleInner<T>` to prevent duplicate drop() call.
- Add a finite test case.